### PR TITLE
Add "starting" state to implement automatic adapter restarts 

### DIFF
--- a/src/main/java/com/hivemq/adapter/sdk/api/state/ProtocolAdapterState.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/state/ProtocolAdapterState.java
@@ -33,6 +33,10 @@ public interface ProtocolAdapterState {
          */
         STARTED,
         /**
+         * Adapter is trying to start upon initial failure
+         */
+        STARTING,
+        /**
          * The adapter was stopped.
          */
         STOPPED


### PR DESCRIPTION
Part of the dealblocker for Toyota, regarding automatic restarts of protocol adapters.
https://docs.google.com/document/d/1MDRjttQhyXod7m_RbunhO4xuLcsNSmmQZL1fy4dTPL0/edit?usp=sharing

Idea is to add an additional state so it would be known that adapter is "starting" (trying to connect), either after failed start or after certain number of errors (max error level reached).

Future reconnects flow:
```
(ui - trigger start | during startup) -> starting -> (successful) -> started
                                                  \> (error connecting) -> starting -> (schedule reconnect) -> ...

(when running) -> (erors encountered, max error level reached) -> starting -> (try to reconnect at interval calculated by current (max) error level)

starting | started -> (ui - trigger stop) -> stopped 

```