### PR TITLE
Deprecated some methods which were giving a wrong assumption

### DIFF
--- a/src/main/java/com/hivemq/adapter/sdk/api/data/DataPoint.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/data/DataPoint.java
@@ -41,4 +41,11 @@ public interface DataPoint {
      * @return the tag name of the data point.
      */
     @NotNull String getTagName();
+
+    /**
+     * @return the tag name of the data point.
+     */
+    @NotNull default String getAdapterId() {
+        return "";
+    }
 }

--- a/src/main/java/com/hivemq/adapter/sdk/api/data/ProtocolAdapterDataSample.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/data/ProtocolAdapterDataSample.java
@@ -55,7 +55,7 @@ public interface ProtocolAdapterDataSample {
     /**
      * @return a map which maps tagName to the list of data points for this tagName
      * @deprecated We dropped support for multiple values per tag name a long time ago. Adapters are not supposed to buffer data. Also, each datapoint carries the information of the tag it belongs to.
-     * Method will be removed in 2026.10. Switch to using @method getDataPointsList() instead.
+     * Method will be removed in 2026.10. Switch to using getDataPointsList() instead.
      */
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @NotNull

--- a/src/main/java/com/hivemq/adapter/sdk/api/data/ProtocolAdapterDataSample.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/data/ProtocolAdapterDataSample.java
@@ -18,6 +18,7 @@ package com.hivemq.adapter.sdk.api.data;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.hivemq.adapter.sdk.api.config.PollingContext;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
@@ -55,10 +56,13 @@ public interface ProtocolAdapterDataSample {
 
     /**
      * @return a map which maps tagName to the list of data points for this tagName
+     * @deprecated We dropped support for multiple values per tag name a long time ago. Adapters are not supposed to buffer data. Also, each datapoint carries the information of the tag it belongs to.
+     * Method will be removed in 2026.10. Switch to using @method getDataPointsList() instead.
      */
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @NotNull
-    @Deprecated() //TODO add removal date
+    @ApiStatus.ScheduledForRemoval(inVersion = "2026.10")
+    @Deprecated()
     Map<String, List<DataPoint>> getDataPoints();
 
     /**

--- a/src/main/java/com/hivemq/adapter/sdk/api/data/ProtocolAdapterDataSample.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/data/ProtocolAdapterDataSample.java
@@ -17,11 +17,9 @@ package com.hivemq.adapter.sdk.api.data;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.hivemq.adapter.sdk.api.config.PollingContext;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -70,5 +68,5 @@ public interface ProtocolAdapterDataSample {
      */
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @NotNull
-    List<DataPoint> getDataPointsList();
+    List<DataPoint> getDataPointList();
 }

--- a/src/main/java/com/hivemq/adapter/sdk/api/data/ProtocolAdapterDataSample.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/data/ProtocolAdapterDataSample.java
@@ -58,5 +58,13 @@ public interface ProtocolAdapterDataSample {
      */
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @NotNull
+    @Deprecated() //TODO add removal date
     Map<String, List<DataPoint>> getDataPoints();
+
+    /**
+     * @return list of data points for the read tags
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @NotNull
+    List<DataPoint> getDataPointsList();
 }

--- a/src/main/java/com/hivemq/adapter/sdk/api/datapoint/DataPointBuilder.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/datapoint/DataPointBuilder.java
@@ -1,127 +1,121 @@
 package com.hivemq.adapter.sdk.api.datapoint;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.jetbrains.annotations.NotNull;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.Optional;
-import java.util.function.Function;
+import java.time.Instant;
 
 public interface DataPointBuilder<R> {
-    
-    @NotNull DataPointBuilder<R> setValue(final @NotNull String value);
 
-    @NotNull DataPointBuilder<R> setValue(final int value);
+    @NotNull DataPointBuilder<R> value(boolean value);
 
-    @NotNull DataPointBuilder<R> setValue(final long value);
+    @NotNull DataPointBuilder<R> value(byte value);
 
-    @NotNull DataPointBuilder<R> setValue(final double value);
+    @NotNull DataPointBuilder<R> value(short value);
 
-    @NotNull DataPointBuilder<R> setValue(final float value);
+    @NotNull DataPointBuilder<R> value(int value);
 
-    @NotNull DataPointBuilder<R> setValue(final boolean value);
+    @NotNull DataPointBuilder<R> value(long value);
 
-    @NotNull DataPointBuilder<R> setValue(final short value);
+    @NotNull DataPointBuilder<R> value(float value);
 
-    @NotNull DataPointBuilder<R> setValue(final @NotNull BigDecimal value);
+    @NotNull DataPointBuilder<R> value(double value);
 
-    @NotNull DataPointBuilder<R> setValue(final @NotNull BigInteger value);
+    @NotNull DataPointBuilder<R> value(@NotNull String value);
 
-    @NotNull DataPointBuilder<R> setValue(final byte @NotNull [] value);
+    @NotNull DataPointBuilder<R> value(byte @NotNull [] value);
 
-    @NotNull DataPointBuilder<R> setNullValue();
+    @NotNull DataPointBuilder<R> value(@NotNull BigDecimal value);
 
-    @NotNull ObjectBuilder<DataPointBuilder<R>> valueStart();
+    @NotNull DataPointBuilder<R> value(@NotNull BigInteger value);
 
-    @NotNull ObjectBuilder<DataPointBuilder<R>> metadataStart();
+    @NotNull DataPointBuilder<R> value(@NotNull JsonNode value);
 
-    @NotNull ObjectBuilder<DataPointBuilder<R>> protocolTagMetadataStart();
+    @NotNull DataPointBuilder<R> valueNull();
 
-    @NotNull ObjectBuilder<DataPointBuilder<R>> protocolDeviceMetadataStart();
+    @NotNull ObjectBuilder<DataPointBuilder<R>> startObjectValue();
 
-    @NotNull ObjectBuilder<DataPointBuilder<R>> adapterDatapointMetadataStart();
+    @NotNull ArrayBuilder<DataPointBuilder<R>> startArrayValue();
 
-    @NotNull ObjectBuilder<DataPointBuilder<R>> adapterTagMetadataStart();
+    @NotNull ObjectBuilder<DataPointBuilder<R>> startObjectMetadata();
 
-    @NotNull ObjectBuilder<DataPointBuilder<R>> adapterDeviceMetadataStart();
+    @NotNull ObjectBuilder<DataPointBuilder<R>> startObjectContext();
 
-    R finish();
+    @NotNull DataPointBuilder<R> timestamp(long epochMillis);
+
+    @NotNull DataPointBuilder<R> timestamp(@NotNull Instant instant);
+
+    R endDataPoint();
 
     interface ObjectBuilder<P> {
 
-        @NotNull ObjectBuilder<P> add(final @NotNull String key, final @NotNull String value);
+        @NotNull ObjectBuilder<P> put(@NotNull String key, boolean value);
 
-        @NotNull ObjectBuilder<P> add(final @NotNull String key, final int value);
+        @NotNull ObjectBuilder<P> put(@NotNull String key, byte value);
 
-        @NotNull ObjectBuilder<P> add(final @NotNull String key, final long value);
+        @NotNull ObjectBuilder<P> put(@NotNull String key, short value);
 
-        @NotNull ObjectBuilder<P> add(final @NotNull String key, final double value);
+        @NotNull ObjectBuilder<P> put(@NotNull String key, int value);
 
-        @NotNull ObjectBuilder<P> add(final @NotNull String key, final float value);
+        @NotNull ObjectBuilder<P> put(@NotNull String key, long value);
 
-        @NotNull ObjectBuilder<P> add(final @NotNull String key, final boolean value);
+        @NotNull ObjectBuilder<P> put(@NotNull String key, float value);
 
-        @NotNull ObjectBuilder<P> add(final @NotNull String key, final @NotNull BigDecimal value);
+        @NotNull ObjectBuilder<P> put(@NotNull String key, double value);
 
-        @NotNull ObjectBuilder<P> add(final @NotNull String key, final @NotNull BigInteger value);
+        @NotNull ObjectBuilder<P> put(@NotNull String key, @NotNull String value);
 
-        @NotNull ObjectBuilder<P> add(final @NotNull String key, final byte @NotNull [] value);
+        @NotNull ObjectBuilder<P> put(@NotNull String key, byte @NotNull [] value);
 
-        @NotNull ObjectBuilder<P> add(final @NotNull String key, final short value);
+        @NotNull ObjectBuilder<P> put(@NotNull String key, @NotNull BigDecimal value);
 
-        @NotNull ObjectBuilder<P> addNull(final @NotNull String key);
+        @NotNull ObjectBuilder<P> put(@NotNull String key, @NotNull BigInteger value);
 
-        @NotNull ObjectBuilder<ObjectBuilder<P>> objectStart(final @NotNull String key);
+        @NotNull ObjectBuilder<P> put(@NotNull String key, @NotNull JsonNode value);
 
-        @NotNull ArrayBuilder<ObjectBuilder<P>> arrayStart(final @NotNull String key);
+        @NotNull ObjectBuilder<P> putNull(@NotNull String key);
 
-        @NotNull P valueStop();
+        @NotNull ObjectBuilder<ObjectBuilder<P>> startObject(@NotNull String key);
 
-        @NotNull P metadataStop();
+        @NotNull ArrayBuilder<ObjectBuilder<P>> startArray(@NotNull String key);
 
-        @NotNull P protocolTagMetadataStop();
-
-        @NotNull P protocolDeviceMetadataStop();
-
-        @NotNull P adapterDatapointMetadataStop();
-
-        @NotNull P adapterTagMetadataStop();
-
-        @NotNull P adapterDeviceMetadataStop();
-
-        @NotNull P objectEnd();
+        @NotNull P endObject();
     }
 
     interface ArrayBuilder<P> {
 
-        @NotNull ArrayBuilder<P> add(final @NotNull String value);
+        @NotNull ArrayBuilder<P> add(boolean value);
 
-        @NotNull ArrayBuilder<P> add(final int value);
+        @NotNull ArrayBuilder<P> add(byte value);
 
-        @NotNull ArrayBuilder<P> add(final long value);
+        @NotNull ArrayBuilder<P> add(short value);
 
-        @NotNull ArrayBuilder<P> add(final double value);
+        @NotNull ArrayBuilder<P> add(int value);
 
-        @NotNull ArrayBuilder<P> add(final float value);
+        @NotNull ArrayBuilder<P> add(long value);
 
-        @NotNull ArrayBuilder<P> add(final boolean value);
+        @NotNull ArrayBuilder<P> add(float value);
 
-        @NotNull ArrayBuilder<P> add(final @NotNull BigDecimal value);
+        @NotNull ArrayBuilder<P> add(double value);
 
-        @NotNull ArrayBuilder<P> add(final @NotNull BigInteger value);
+        @NotNull ArrayBuilder<P> add(@NotNull String value);
 
-        @NotNull ArrayBuilder<P> add(final byte @NotNull [] value);
+        @NotNull ArrayBuilder<P> add(byte @NotNull [] value);
 
-        @NotNull ArrayBuilder<P> add(final short value);
+        @NotNull ArrayBuilder<P> add(@NotNull BigDecimal value);
+
+        @NotNull ArrayBuilder<P> add(@NotNull BigInteger value);
+
+        @NotNull ArrayBuilder<P> add(@NotNull JsonNode value);
 
         @NotNull ArrayBuilder<P> addNull();
 
-        @NotNull ObjectBuilder<ArrayBuilder<P>> objectStart();
+        @NotNull ObjectBuilder<ArrayBuilder<P>> startObject();
 
-        @NotNull P arrayEnd();
+        @NotNull ArrayBuilder<ArrayBuilder<P>> startArray();
+
+        @NotNull P endArray();
     }
 }

--- a/src/main/java/com/hivemq/adapter/sdk/api/datapoint/DataPointBuilder.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/datapoint/DataPointBuilder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.adapter.sdk.api.datapoint;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/src/main/java/com/hivemq/adapter/sdk/api/datapoint/DataPointBuilder.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/datapoint/DataPointBuilder.java
@@ -1,0 +1,127 @@
+package com.hivemq.adapter.sdk.api.datapoint;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.jetbrains.annotations.NotNull;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Optional;
+import java.util.function.Function;
+
+public interface DataPointBuilder<R> {
+    
+    @NotNull DataPointBuilder<R> setValue(final @NotNull String value);
+
+    @NotNull DataPointBuilder<R> setValue(final int value);
+
+    @NotNull DataPointBuilder<R> setValue(final long value);
+
+    @NotNull DataPointBuilder<R> setValue(final double value);
+
+    @NotNull DataPointBuilder<R> setValue(final float value);
+
+    @NotNull DataPointBuilder<R> setValue(final boolean value);
+
+    @NotNull DataPointBuilder<R> setValue(final short value);
+
+    @NotNull DataPointBuilder<R> setValue(final @NotNull BigDecimal value);
+
+    @NotNull DataPointBuilder<R> setValue(final @NotNull BigInteger value);
+
+    @NotNull DataPointBuilder<R> setValue(final byte @NotNull [] value);
+
+    @NotNull DataPointBuilder<R> setNullValue();
+
+    @NotNull ObjectBuilder<DataPointBuilder<R>> valueStart();
+
+    @NotNull ObjectBuilder<DataPointBuilder<R>> metadataStart();
+
+    @NotNull ObjectBuilder<DataPointBuilder<R>> protocolTagMetadataStart();
+
+    @NotNull ObjectBuilder<DataPointBuilder<R>> protocolDeviceMetadataStart();
+
+    @NotNull ObjectBuilder<DataPointBuilder<R>> adapterDatapointMetadataStart();
+
+    @NotNull ObjectBuilder<DataPointBuilder<R>> adapterTagMetadataStart();
+
+    @NotNull ObjectBuilder<DataPointBuilder<R>> adapterDeviceMetadataStart();
+
+    R finish();
+
+    interface ObjectBuilder<P> {
+
+        @NotNull ObjectBuilder<P> add(final @NotNull String key, final @NotNull String value);
+
+        @NotNull ObjectBuilder<P> add(final @NotNull String key, final int value);
+
+        @NotNull ObjectBuilder<P> add(final @NotNull String key, final long value);
+
+        @NotNull ObjectBuilder<P> add(final @NotNull String key, final double value);
+
+        @NotNull ObjectBuilder<P> add(final @NotNull String key, final float value);
+
+        @NotNull ObjectBuilder<P> add(final @NotNull String key, final boolean value);
+
+        @NotNull ObjectBuilder<P> add(final @NotNull String key, final @NotNull BigDecimal value);
+
+        @NotNull ObjectBuilder<P> add(final @NotNull String key, final @NotNull BigInteger value);
+
+        @NotNull ObjectBuilder<P> add(final @NotNull String key, final byte @NotNull [] value);
+
+        @NotNull ObjectBuilder<P> add(final @NotNull String key, final short value);
+
+        @NotNull ObjectBuilder<P> addNull(final @NotNull String key);
+
+        @NotNull ObjectBuilder<ObjectBuilder<P>> objectStart(final @NotNull String key);
+
+        @NotNull ArrayBuilder<ObjectBuilder<P>> arrayStart(final @NotNull String key);
+
+        @NotNull P valueStop();
+
+        @NotNull P metadataStop();
+
+        @NotNull P protocolTagMetadataStop();
+
+        @NotNull P protocolDeviceMetadataStop();
+
+        @NotNull P adapterDatapointMetadataStop();
+
+        @NotNull P adapterTagMetadataStop();
+
+        @NotNull P adapterDeviceMetadataStop();
+
+        @NotNull P objectEnd();
+    }
+
+    interface ArrayBuilder<P> {
+
+        @NotNull ArrayBuilder<P> add(final @NotNull String value);
+
+        @NotNull ArrayBuilder<P> add(final int value);
+
+        @NotNull ArrayBuilder<P> add(final long value);
+
+        @NotNull ArrayBuilder<P> add(final double value);
+
+        @NotNull ArrayBuilder<P> add(final float value);
+
+        @NotNull ArrayBuilder<P> add(final boolean value);
+
+        @NotNull ArrayBuilder<P> add(final @NotNull BigDecimal value);
+
+        @NotNull ArrayBuilder<P> add(final @NotNull BigInteger value);
+
+        @NotNull ArrayBuilder<P> add(final byte @NotNull [] value);
+
+        @NotNull ArrayBuilder<P> add(final short value);
+
+        @NotNull ArrayBuilder<P> addNull();
+
+        @NotNull ObjectBuilder<ArrayBuilder<P>> objectStart();
+
+        @NotNull P arrayEnd();
+    }
+}

--- a/src/main/java/com/hivemq/adapter/sdk/api/datapoint/DataPointListBuilder.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/datapoint/DataPointListBuilder.java
@@ -1,0 +1,10 @@
+package com.hivemq.adapter.sdk.api.datapoint;
+
+import org.jetbrains.annotations.NotNull;
+
+public interface DataPointListBuilder {
+
+    DataPointBuilder<DataPointListBuilder> dataPoint(final @NotNull String tagName);
+
+    void send();
+}

--- a/src/main/java/com/hivemq/adapter/sdk/api/datapoint/DataPointListBuilder.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/datapoint/DataPointListBuilder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.hivemq.adapter.sdk.api.datapoint;
 
 import com.hivemq.adapter.sdk.api.tag.Tag;

--- a/src/main/java/com/hivemq/adapter/sdk/api/datapoint/DataPointListBuilder.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/datapoint/DataPointListBuilder.java
@@ -1,10 +1,11 @@
 package com.hivemq.adapter.sdk.api.datapoint;
 
+import com.hivemq.adapter.sdk.api.tag.Tag;
 import org.jetbrains.annotations.NotNull;
 
 public interface DataPointListBuilder {
 
-    DataPointBuilder<DataPointListBuilder> dataPoint(final @NotNull String tagName);
+    @NotNull DataPointBuilder<DataPointListBuilder> addDataPoint(@NotNull Tag tag);
 
-    void send();
+    void publish();
 }

--- a/src/main/java/com/hivemq/adapter/sdk/api/factories/AdapterFactories.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/factories/AdapterFactories.java
@@ -15,11 +15,15 @@
  */
 package com.hivemq.adapter.sdk.api.factories;
 
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * This class offers access to factory classes for implementations of SDK interfaces.
+ * @deprecated no longer needed. To be removed in 2026.10
  */
+@ApiStatus.ScheduledForRemoval(inVersion = "2026.10")
+@Deprecated
 public interface AdapterFactories {
 
     /**

--- a/src/main/java/com/hivemq/adapter/sdk/api/polling/PollingOutput.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/polling/PollingOutput.java
@@ -17,6 +17,7 @@ package com.hivemq.adapter.sdk.api.polling;
 
 import com.hivemq.adapter.sdk.api.data.DataPoint;
 import com.hivemq.adapter.sdk.api.datapoint.DataPointListBuilder;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -37,7 +38,10 @@ public interface PollingOutput {
      *
      * @param tagName  the name for the tag of this data point
      * @param tagValue the value of this data point
+     * @deprecated replaced by {@link #dataPointsPublisher()} to support better performance and more complex data structures.
+     * Method will be removed in 2026.10. Switch to using @method dataPointsPublisher() instead.
      */
+    @ApiStatus.ScheduledForRemoval(inVersion = "2026.10")
     @Deprecated
     void addDataPoint(final @NotNull String tagName, final @NotNull Object tagValue);
 
@@ -45,7 +49,10 @@ public interface PollingOutput {
      * Adds the given data point to this sample.
      *
      * @param dataPoint the data point to add.
+     * @deprecated replaced by {@link #dataPointsPublisher()} to support better performance and more complex data structures.
+     * Method will be removed in 2026.10. Switch to using @method dataPointsPublisher() instead.
      */
+    @ApiStatus.ScheduledForRemoval(inVersion = "2026.10")
     @Deprecated
     void addDataPoint(final @NotNull DataPoint dataPoint);
 
@@ -57,7 +64,10 @@ public interface PollingOutput {
     /**
      * Signals Edge that all data points are added and the further processing is done.
      * If no data points were added until this point, no publish will be created.
+     * @deprecated
+     * the new builders in dataPointsPublisher() have a callback to signal that all data points are added and the publish can be created. So this method is not needed anymore.
      */
+    @ApiStatus.ScheduledForRemoval(inVersion = "2026.10")
     @Deprecated
     void finish();
 

--- a/src/main/java/com/hivemq/adapter/sdk/api/polling/PollingOutput.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/polling/PollingOutput.java
@@ -39,7 +39,7 @@ public interface PollingOutput {
      * @param tagName  the name for the tag of this data point
      * @param tagValue the value of this data point
      * @deprecated replaced by {@link #dataPointListPublisher()} to support better performance and more complex data structures.
-     * Method will be removed in 2026.10. Switch to using @method dataPointsPublisher() instead.
+     * Method will be removed in 2026.10. Switch to using dataPointsPublisher() instead.
      */
     @ApiStatus.ScheduledForRemoval(inVersion = "2026.10")
     @Deprecated
@@ -50,7 +50,7 @@ public interface PollingOutput {
      *
      * @param dataPoint the data point to add.
      * @deprecated replaced by {@link #dataPointListPublisher()} to support better performance and more complex data structures.
-     * Method will be removed in 2026.10. Switch to using @method dataPointsPublisher() instead.
+     * Method will be removed in 2026.10. Switch to using dataPointsPublisher() instead.
      */
     @ApiStatus.ScheduledForRemoval(inVersion = "2026.10")
     @Deprecated

--- a/src/main/java/com/hivemq/adapter/sdk/api/polling/PollingOutput.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/polling/PollingOutput.java
@@ -38,7 +38,7 @@ public interface PollingOutput {
      *
      * @param tagName  the name for the tag of this data point
      * @param tagValue the value of this data point
-     * @deprecated replaced by {@link #dataPointsPublisher()} to support better performance and more complex data structures.
+     * @deprecated replaced by {@link #dataPointListPublisher()} to support better performance and more complex data structures.
      * Method will be removed in 2026.10. Switch to using @method dataPointsPublisher() instead.
      */
     @ApiStatus.ScheduledForRemoval(inVersion = "2026.10")
@@ -49,7 +49,7 @@ public interface PollingOutput {
      * Adds the given data point to this sample.
      *
      * @param dataPoint the data point to add.
-     * @deprecated replaced by {@link #dataPointsPublisher()} to support better performance and more complex data structures.
+     * @deprecated replaced by {@link #dataPointListPublisher()} to support better performance and more complex data structures.
      * Method will be removed in 2026.10. Switch to using @method dataPointsPublisher() instead.
      */
     @ApiStatus.ScheduledForRemoval(inVersion = "2026.10")
@@ -59,7 +59,7 @@ public interface PollingOutput {
     /**
      * Get the publisher to construct and publish datapoints.
      */
-    @NotNull DataPointListBuilder dataPointsPublisher();
+    @NotNull DataPointListBuilder dataPointListPublisher();
 
     /**
      * Signals Edge that all data points are added and the further processing is done.

--- a/src/main/java/com/hivemq/adapter/sdk/api/polling/PollingOutput.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/polling/PollingOutput.java
@@ -50,9 +50,9 @@ public interface PollingOutput {
     void addDataPoint(final @NotNull DataPoint dataPoint);
 
     /**
-     * Get the sender to produce datapoints
+     * Get the publisher to construct and publish datapoints.
      */
-    @NotNull DataPointListBuilder dataPointSender();
+    @NotNull DataPointListBuilder dataPointsPublisher();
 
     /**
      * Signals Edge that all data points are added and the further processing is done.

--- a/src/main/java/com/hivemq/adapter/sdk/api/polling/PollingOutput.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/polling/PollingOutput.java
@@ -16,6 +16,7 @@
 package com.hivemq.adapter.sdk.api.polling;
 
 import com.hivemq.adapter.sdk.api.data.DataPoint;
+import com.hivemq.adapter.sdk.api.datapoint.DataPointListBuilder;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -37,6 +38,7 @@ public interface PollingOutput {
      * @param tagName  the name for the tag of this data point
      * @param tagValue the value of this data point
      */
+    @Deprecated
     void addDataPoint(final @NotNull String tagName, final @NotNull Object tagValue);
 
     /**
@@ -44,12 +46,19 @@ public interface PollingOutput {
      *
      * @param dataPoint the data point to add.
      */
+    @Deprecated
     void addDataPoint(final @NotNull DataPoint dataPoint);
+
+    /**
+     * Get the sender to produce datapoints
+     */
+    @NotNull DataPointListBuilder dataPointSender();
 
     /**
      * Signals Edge that all data points are added and the further processing is done.
      * If no data points were added until this point, no publish will be created.
      */
+    @Deprecated
     void finish();
 
     /**

--- a/src/main/java/com/hivemq/adapter/sdk/api/polling/batch/BatchPollingOutput.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/polling/batch/BatchPollingOutput.java
@@ -40,7 +40,7 @@ public interface BatchPollingOutput {
      * @param tagName  the name for the tag of this data point
      * @param tagValue the value of this data point
      * @deprecated replaced by {@link #dataPointListPublisher()} to support better performance and more complex data structures.
-     * Method will be removed in 2026.10. Switch to using @method dataPointsPublisher() instead.
+     * Method will be removed in 2026.10. Switch to using dataPointsPublisher() instead.
      */
     @ApiStatus.ScheduledForRemoval(inVersion = "2026.10")
     @Deprecated
@@ -51,7 +51,7 @@ public interface BatchPollingOutput {
      *
      * @param dataPoint the data point to add.
      * @deprecated replaced by {@link #dataPointListPublisher()} to support better performance and more complex data structures.
-     * Method will be removed in 2026.10. Switch to using @method dataPointsPublisher() instead.
+     * Method will be removed in 2026.10. Switch to using dataPointsPublisher() instead.
      */
     @ApiStatus.ScheduledForRemoval(inVersion = "2026.10")
     @Deprecated

--- a/src/main/java/com/hivemq/adapter/sdk/api/polling/batch/BatchPollingOutput.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/polling/batch/BatchPollingOutput.java
@@ -18,6 +18,7 @@ package com.hivemq.adapter.sdk.api.polling.batch;
 import com.hivemq.adapter.sdk.api.data.DataPoint;
 import com.hivemq.adapter.sdk.api.datapoint.DataPointListBuilder;
 import com.hivemq.adapter.sdk.api.polling.PollingProtocolAdapter;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -38,7 +39,10 @@ public interface BatchPollingOutput {
      *
      * @param tagName  the name for the tag of this data point
      * @param tagValue the value of this data point
+     * @deprecated replaced by {@link #dataPointsPublisher()} to support better performance and more complex data structures.
+     * Method will be removed in 2026.10. Switch to using @method dataPointsPublisher() instead.
      */
+    @ApiStatus.ScheduledForRemoval(inVersion = "2026.10")
     @Deprecated
     void addDataPoint(final @NotNull String tagName, final @NotNull Object tagValue);
 
@@ -46,7 +50,10 @@ public interface BatchPollingOutput {
      * Adds the given data point to this sample.
      *
      * @param dataPoint the data point to add.
+     * @deprecated replaced by {@link #dataPointsPublisher()} to support better performance and more complex data structures.
+     * Method will be removed in 2026.10. Switch to using @method dataPointsPublisher() instead.
      */
+    @ApiStatus.ScheduledForRemoval(inVersion = "2026.10")
     @Deprecated
     void addDataPoint(final @NotNull DataPoint dataPoint);
 
@@ -58,7 +65,10 @@ public interface BatchPollingOutput {
     /**
      * Signals Edge that all data points are added and the further processing is done.
      * If no data points were added until this point, no publish will be created.
+     * @deprecated not needed with the new builder from {@link #dataPointsPublisher()}
+     * Method will be removed in 2026.10.
      */
+    @ApiStatus.ScheduledForRemoval(inVersion = "2026.10")
     @Deprecated
     void finish();
 

--- a/src/main/java/com/hivemq/adapter/sdk/api/polling/batch/BatchPollingOutput.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/polling/batch/BatchPollingOutput.java
@@ -51,9 +51,9 @@ public interface BatchPollingOutput {
     void addDataPoint(final @NotNull DataPoint dataPoint);
 
     /**
-     * Get the sender to produce datapoints
+     * Get the publisher to construct and publish datapoints.
      */
-    @NotNull DataPointListBuilder dataPointSender();
+    @NotNull DataPointListBuilder dataPointsPublisher();
 
     /**
      * Signals Edge that all data points are added and the further processing is done.

--- a/src/main/java/com/hivemq/adapter/sdk/api/polling/batch/BatchPollingOutput.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/polling/batch/BatchPollingOutput.java
@@ -16,6 +16,7 @@
 package com.hivemq.adapter.sdk.api.polling.batch;
 
 import com.hivemq.adapter.sdk.api.data.DataPoint;
+import com.hivemq.adapter.sdk.api.datapoint.DataPointListBuilder;
 import com.hivemq.adapter.sdk.api.polling.PollingProtocolAdapter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -38,6 +39,7 @@ public interface BatchPollingOutput {
      * @param tagName  the name for the tag of this data point
      * @param tagValue the value of this data point
      */
+    @Deprecated
     void addDataPoint(final @NotNull String tagName, final @NotNull Object tagValue);
 
     /**
@@ -45,12 +47,19 @@ public interface BatchPollingOutput {
      *
      * @param dataPoint the data point to add.
      */
+    @Deprecated
     void addDataPoint(final @NotNull DataPoint dataPoint);
+
+    /**
+     * Get the sender to produce datapoints
+     */
+    @NotNull DataPointListBuilder dataPointSender();
 
     /**
      * Signals Edge that all data points are added and the further processing is done.
      * If no data points were added until this point, no publish will be created.
      */
+    @Deprecated
     void finish();
 
     /**

--- a/src/main/java/com/hivemq/adapter/sdk/api/polling/batch/BatchPollingOutput.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/polling/batch/BatchPollingOutput.java
@@ -39,7 +39,7 @@ public interface BatchPollingOutput {
      *
      * @param tagName  the name for the tag of this data point
      * @param tagValue the value of this data point
-     * @deprecated replaced by {@link #dataPointsPublisher()} to support better performance and more complex data structures.
+     * @deprecated replaced by {@link #dataPointListPublisher()} to support better performance and more complex data structures.
      * Method will be removed in 2026.10. Switch to using @method dataPointsPublisher() instead.
      */
     @ApiStatus.ScheduledForRemoval(inVersion = "2026.10")
@@ -50,7 +50,7 @@ public interface BatchPollingOutput {
      * Adds the given data point to this sample.
      *
      * @param dataPoint the data point to add.
-     * @deprecated replaced by {@link #dataPointsPublisher()} to support better performance and more complex data structures.
+     * @deprecated replaced by {@link #dataPointListPublisher()} to support better performance and more complex data structures.
      * Method will be removed in 2026.10. Switch to using @method dataPointsPublisher() instead.
      */
     @ApiStatus.ScheduledForRemoval(inVersion = "2026.10")
@@ -60,12 +60,12 @@ public interface BatchPollingOutput {
     /**
      * Get the publisher to construct and publish datapoints.
      */
-    @NotNull DataPointListBuilder dataPointsPublisher();
+    @NotNull DataPointListBuilder dataPointListPublisher();
 
     /**
      * Signals Edge that all data points are added and the further processing is done.
      * If no data points were added until this point, no publish will be created.
-     * @deprecated not needed with the new builder from {@link #dataPointsPublisher()}
+     * @deprecated not needed with the new builder from {@link #dataPointListPublisher()}
      * Method will be removed in 2026.10.
      */
     @ApiStatus.ScheduledForRemoval(inVersion = "2026.10")

--- a/src/main/java/com/hivemq/adapter/sdk/api/streaming/ProtocolAdapterTagStreamingService.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/streaming/ProtocolAdapterTagStreamingService.java
@@ -16,6 +16,7 @@
 package com.hivemq.adapter.sdk.api.streaming;
 
 import com.hivemq.adapter.sdk.api.data.DataPoint;
+import com.hivemq.adapter.sdk.api.datapoint.DataPointListBuilder;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;

--- a/src/main/java/com/hivemq/adapter/sdk/api/streaming/ProtocolAdapterTagStreamingService.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/streaming/ProtocolAdapterTagStreamingService.java
@@ -22,10 +22,9 @@ import org.jetbrains.annotations.NotNull;
 import java.util.List;
 
 public interface ProtocolAdapterTagStreamingService {
-    default void feed(@NotNull List<DataPoint> dataPoints) {
-        feed("", dataPoints);
-    }
 
-    @Deprecated(since = "This API will be removed by 2026.10. Please migrate to the feed method without tagName.")
+    @NotNull DataPointListBuilder dataPointSender();
+
+    @Deprecated
     void feed(@NotNull String tag, @NotNull List<DataPoint> dataPoints);
 }

--- a/src/main/java/com/hivemq/adapter/sdk/api/streaming/ProtocolAdapterTagStreamingService.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/streaming/ProtocolAdapterTagStreamingService.java
@@ -28,7 +28,7 @@ public interface ProtocolAdapterTagStreamingService {
 
     /**
      * @deprecated replaced by {@link #dataPointsPublisher()} to support better performance and more complex data structures.
-     * Method will be removed in 2026.10. Switch to using @method dataPointsPublisher() instead.
+     * Method will be removed in 2026.10. Switch to using dataPointsPublisher() instead.
      */
     @ApiStatus.ScheduledForRemoval(inVersion = "2026.10")
     @Deprecated

--- a/src/main/java/com/hivemq/adapter/sdk/api/streaming/ProtocolAdapterTagStreamingService.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/streaming/ProtocolAdapterTagStreamingService.java
@@ -17,6 +17,7 @@ package com.hivemq.adapter.sdk.api.streaming;
 
 import com.hivemq.adapter.sdk.api.data.DataPoint;
 import com.hivemq.adapter.sdk.api.datapoint.DataPointListBuilder;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
@@ -25,6 +26,11 @@ public interface ProtocolAdapterTagStreamingService {
 
     @NotNull DataPointListBuilder dataPointsPublisher();
 
+    /**
+     * @deprecated replaced by {@link #dataPointsPublisher()} to support better performance and more complex data structures.
+     * Method will be removed in 2026.10. Switch to using @method dataPointsPublisher() instead.
+     */
+    @ApiStatus.ScheduledForRemoval(inVersion = "2026.10")
     @Deprecated
     void feed(@NotNull String tag, @NotNull List<DataPoint> dataPoints);
 }

--- a/src/main/java/com/hivemq/adapter/sdk/api/streaming/ProtocolAdapterTagStreamingService.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/streaming/ProtocolAdapterTagStreamingService.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 public interface ProtocolAdapterTagStreamingService {
 
-    @NotNull DataPointListBuilder dataPointSender();
+    @NotNull DataPointListBuilder dataPointsPublisher();
 
     @Deprecated
     void feed(@NotNull String tag, @NotNull List<DataPoint> dataPoints);


### PR DESCRIPTION
**Motivation**

Resolves #EDG-66

**Changes**
Cleanup to get rid of some methids which were giving the impression that adapters would emit multiple DataPoints for the same tag at any given time.