### PR TITLE
EDG-255 Reclaim Tag Ownership from Adapters, v2 - phase 1, introduce GenericTag (SDK)

### DIFF
--- a/src/main/java/com/hivemq/adapter/sdk/api/ProtocolAdapterInformation.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/ProtocolAdapterInformation.java
@@ -18,6 +18,7 @@ package com.hivemq.adapter.sdk.api;
 
 import com.hivemq.adapter.sdk.api.config.ProtocolSpecificAdapterConfig;
 import com.hivemq.adapter.sdk.api.tag.Tag;
+import com.hivemq.adapter.sdk.api.tag.TagDefinition;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -95,14 +96,27 @@ public interface ProtocolAdapterInformation {
 
 
     /**
-     * A bean class that will be reflected upon by the framework to determine the structural requirements of the
-     * tag configuration associated with an adapter instance. It is expected that the bean class supplied, be marked up
-     * with Jackson annotation.
+     * Old-style adapters override this to return their XxxTag class.
+     * New-style adapters leave this as null and override {@link #tagDefinitionClass()} instead.
      *
-     * @return The class that represents (and will encapsulate) the configuration requirements of the adapter's tags
+     * @return The Tag class for old-style adapters, or null for new-style adapters
      */
-    @NotNull
-    Class<? extends Tag> tagConfigurationClass();
+    @Nullable
+    default Class<? extends Tag> tagConfigurationClass() {
+        return null;
+    }
+
+    /**
+     * New-style adapters override this to return their TagDefinition class.
+     * Edge uses this to construct a GenericTag rather than deserialising an adapter-specific Tag class.
+     * Old-style adapters leave this as null and continue to use {@link #tagConfigurationClass()}.
+     *
+     * @return the TagDefinition class for new-style adapters, or null for old-style adapters
+     */
+    @Nullable
+    default Class<? extends TagDefinition> tagDefinitionClass() {
+        return null;
+    }
 
     /**
      * A bean class that will be reflected upon by the framework to determine the structural requirements of the

--- a/src/main/java/com/hivemq/adapter/sdk/api/factories/ProtocolAdapterFactory.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/factories/ProtocolAdapterFactory.java
@@ -20,11 +20,14 @@ import com.hivemq.adapter.sdk.api.ProtocolAdapter;
 import com.hivemq.adapter.sdk.api.ProtocolAdapterInformation;
 import com.hivemq.adapter.sdk.api.config.ProtocolSpecificAdapterConfig;
 import com.hivemq.adapter.sdk.api.model.ProtocolAdapterInput;
+import com.hivemq.adapter.sdk.api.tag.GenericTag;
 import com.hivemq.adapter.sdk.api.tag.Tag;
+import com.hivemq.adapter.sdk.api.tag.TagDefinition;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -78,18 +81,29 @@ public interface ProtocolAdapterFactory<E extends ProtocolSpecificAdapterConfig>
     default @NotNull List<? extends Tag> convertTagDefinitionObjects(
             final @NotNull ObjectMapper objectMapper, final @NotNull List<Map<String, Object>> tagList) {
         return tagList.stream()
-                .map(tagMap -> objectMapper.convertValue(tagMap, getInformation().tagConfigurationClass()))
+                .map(tagMap -> convertTagDefinitionObject(objectMapper, tagMap))
                 .collect(Collectors.toList());
     }
 
     /**
      * @param objectMapper the object mapper that converts the map to the actual tag
-     * @param tag      a map that is a tag
+     * @param tagMap       a map that is a tag
      * @return a parsed tag object for this adapter
      */
     default @NotNull Tag convertTagDefinitionObject(
-            final @NotNull ObjectMapper objectMapper, final @NotNull Map<String, Object> tag) {
-        return objectMapper.convertValue(tag, getInformation().tagConfigurationClass());
+            final @NotNull ObjectMapper objectMapper, final @NotNull Map<String, Object> tagMap) {
+        if (getInformation().tagDefinitionClass() != null) {
+            // new-style: deserialise only the definition sub-map, wrap in GenericTag
+            final TagDefinition definition = objectMapper.convertValue(
+                    tagMap.get("definition"), getInformation().tagDefinitionClass());
+            return new GenericTag(
+                    (String) tagMap.get("name"),
+                    Objects.requireNonNullElse((String) tagMap.get("description"), ""),
+                    definition);
+        } else {
+            // old-style: deserialise full tag map into XxxTag class
+            return objectMapper.convertValue(tagMap, getInformation().tagConfigurationClass());
+        }
     }
 
     /**

--- a/src/main/java/com/hivemq/adapter/sdk/api/tag/GenericTag.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/tag/GenericTag.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.adapter.sdk.api.tag;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+/**
+ * The canonical Tag implementation owned by Edge. Protocol adapters that have migrated away from their
+ * own XxxTag class use this class instead.
+ * <p>
+ * The {@code scope} field holds the adapter instance ID and is set by Edge infrastructure after construction.
+ * It is excluded from {@code equals} and {@code hashCode} as it is infrastructure metadata, not tag identity.
+ */
+public class GenericTag implements Tag {
+
+    private final @NotNull String name;
+    private final @NotNull String description;
+    private final @NotNull TagDefinition definition;
+    private @NotNull String scope = "";
+
+    public GenericTag(
+            final @NotNull String name,
+            final @NotNull String description,
+            final @NotNull TagDefinition definition) {
+        this.name = name;
+        this.description = description;
+        this.definition = definition;
+    }
+
+    @Override
+    public @NotNull String getName() {
+        return name;
+    }
+
+    @Override
+    public @NotNull String getDescription() {
+        return description;
+    }
+
+    @Override
+    public @NotNull TagDefinition getDefinition() {
+        return definition;
+    }
+
+    @Override
+    public @NotNull String getScope() {
+        return scope;
+    }
+
+    @Override
+    public void setScope(final @NotNull String scope) {
+        this.scope = scope;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (!(o instanceof GenericTag that)) return false;
+        return Objects.equals(name, that.name)
+                && Objects.equals(description, that.description)
+                && Objects.equals(definition, that.definition);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, description, definition);
+    }
+
+    @Override
+    public String toString() {
+        return "GenericTag{name='" + name + "', description='" + description
+                + "', definition=" + definition + "', scope='" + scope + "'}";
+    }
+}

--- a/src/main/java/com/hivemq/adapter/sdk/api/tag/Tag.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/tag/Tag.java
@@ -28,4 +28,15 @@ public interface Tag {
     @NotNull
     String getDescription();
 
+    /** Returns the ID of the adapter instance that owns this tag. Returns empty string for old-style tag implementations. */
+    @NotNull
+    default String getScope() {
+        return "";
+    }
+
+    /** Sets the adapter instance scope. No-op for old-style tag implementations. */
+    default void setScope(final @NotNull String scope) {
+        // no-op for old-style implementations
+    }
+
 }


### PR DESCRIPTION
## Motivation

A `Tag` is an Edge concept. It represents a named, described data point as Edge understands it — with a name, a description, and a lifecycle. A `TagDefinition` is the adapter's concern: it is the adapter-specific addressing information needed to locate that data point on a device (e.g. a Modbus register address, an OPC-UA node ID).

**Edge should have complete control over what a tag *is* and how it behaves.** Protocol adapters should only own what is necessary to address a tag on the device — i.e. the `TagDefinition`. Adapters receive `Tag` objects and pass them back to Edge, but they must not define or own the `Tag` implementation.

### Approach

The migration is done in phases. Phases 1 and 2 are **fully compatible** — no existing adapter needs to change. Phase 3 is **incompatible** and cleans up the SDK once all adapters have migrated. Phase 4 **seals** the interface to enforce the invariant permanently.

## Phase 1 — SDK and Edge changes (compatible, no adapter changes required)

### Step 1A — Add `GenericTag` to the SDK

### Step 1B — Add `getScope()` and `setScope()` to the `Tag` interface

### Step 1C — Add `tagDefinitionClass()` to `ProtocolAdapterInformation`

### Step 1D — Update `ProtocolAdapterFactory` default methods

### Step 1E — Set scope in `ProtocolAdapterConfigConverter`

### What Phase 1 does NOT change

- All `XxxTag` classes — untouched
- All `XxxTagDefinition` classes — untouched
- All `XxxProtocolAdapterInformation` classes — untouched
- All adapter constructors and cast sites — untouched
- `TagEntity.java`, `DomainTag.java`, `ProtocolAdapterEntity.java` — untouched

### Observable effect after Phase 1

- All adapters continue to work exactly as before (old-style path in dispatcher)
- `tag.getScope()` returns `""` for all tags (old-style `setScope()` is a no-op)
- `GenericTag` exists in the SDK, ready for adopters