### PR TITLE
Add retry logic to Maven Central publish and upgrade plugin

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,4 +24,20 @@ jobs:
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-        run: ./gradlew publishToMavenCentral
+        run: |
+          max_attempts=3
+          delay=30
+          for attempt in $(seq 1 $max_attempts); do
+            echo "Attempt $attempt of $max_attempts"
+            if ./gradlew publishToMavenCentral; then
+              echo "Publish succeeded on attempt $attempt"
+              exit 0
+            fi
+            if [ "$attempt" -lt "$max_attempts" ]; then
+              echo "Publish failed, retrying in ${delay}s..."
+              sleep $delay
+              delay=$((delay * 2))
+            fi
+          done
+          echo "Publish failed after $max_attempts attempts"
+          exit 1

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ victools="4.38.0"
 plugin-defaults = "0.2.0"
 plugin-javadoc-links = "0.9.0"
 plugin-hivemq-license = "1.3.2"
-plugin-maven-central-publishing = "0.4.1"
+plugin-maven-central-publishing = "0.5.0"
 plugin-metadata = "0.6.0"
 plugin-spotless = "7.0.2"
 


### PR DESCRIPTION
## Summary
- Add 3-attempt retry with exponential backoff (30s, 60s) for `publishToMavenCentral` Gradle task
- Upgrade `maven-central-publishing` plugin from 0.4.1 to 0.5.0
- Addresses recurring `SocketTimeoutException` failures due to Maven Central latency spikes

## Test plan
- [ ] Verify Gradle resolves the new plugin version (0.5.0) successfully
- [ ] Manually trigger publish workflow on a test release to confirm retry logic works