### PR TITLE
chore: Update dependencies for 2026.8

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,16 +1,16 @@
 [versions]
 jackson= "2.14.2"
 jetbrains-annotations = "24.1.0"
-swagger-annotations = "2.2.41"
+swagger-annotations = "2.2.48"
 victools="4.38.0"
 
 #Plugin Versions
-plugin-defaults = "0.2.0"
-plugin-javadoc-links = "0.9.0"
-plugin-hivemq-license = "1.3.2"
+plugin-defaults = "0.3.0"
+plugin-javadoc-links = "0.10.0"
+plugin-hivemq-license = "1.3.5"
 plugin-maven-central-publishing = "0.5.0"
-plugin-metadata = "0.6.0"
-plugin-spotless = "7.0.2"
+plugin-metadata = "0.7.0"
+plugin-spotless = "7.2.1"
 
 
 [libraries]


### PR DESCRIPTION
## Summary

Update dependencies for release 2026.8, synced from renovate PRs hivemq/hivemq-edge#1421 (patch) and hivemq/hivemq-edge#1194 (minor).

## Changes

| Library | Old Version | New Version |
| --- | --- | --- |
| swagger-annotations | 2.2.41 | 2.2.48 |
| plugin-defaults | 0.2.0 | 0.3.0 |
| plugin-javadoc-links | 0.9.0 | 0.10.0 |
| plugin-hivemq-license | 1.3.2 | 1.3.5 |
| plugin-metadata | 0.6.0 | 0.7.0 |
| plugin-spotless | 7.0.2 | 7.2.1 |