### PR TITLE
ci: add Renovate configuration to enable Dependency Dashboard

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,15 @@
+{
+    $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+    extends: [
+        'local>hivemq/renovate-config:default.json5',
+    ],
+    baseBranchPatterns: [
+        'master',
+        'renovate-playground',
+    ],
+    useBaseBranchConfig: 'merge',
+    branchPrefix: 'renovate/hivemq-edge-adapter-sdk/',
+    addLabels: [
+        'edge-team',
+    ],
+}


### PR DESCRIPTION
## Summary
- Adds `renovate.json5` at repo root, extending the shared `local>hivemq/renovate-config:default.json5`.
- Required for this repo to be picked up by the central Renovate workflow in `hivemq-edge-composite` (`.github/workflows/renovate-dependencies.yml`).

## Why
The `batch refresh-dashboard --group edge` step in the central workflow currently fails for this repo because it has no Renovate Dependency Dashboard issue. Renovate creates the dashboard automatically on its first scan once this config is merged (and the Renovate GitHub App is installed on the repo).

## Test plan
- [ ] Renovate GitHub App is installed on this repo (org-level action, separate from this PR).
- [ ] After merge, Renovate opens a Dependency Dashboard issue on the next scan.
- [ ] `batch refresh-dashboard --group edge` from the central workflow succeeds for this repo.