### PR TITLE
[EDG-581] Align jackson version with composite

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-jackson= "2.14.2"
+jackson= "2.21.3"
 jetbrains-annotations = "24.1.0"
 swagger-annotations = "2.2.48"
 victools="4.38.0"


### PR DESCRIPTION
## Summary
- Bump `jackson` from `2.14.2` to `2.21.3` so the adapter SDK matches the version used by `hivemq-edge` and the rest of the Edge composite.
- Resolves the composite version-conflict check failures for `jackson-core`, `jackson-bom`, `jackson-dataformat-yaml`, `jackson-jakarta-rs-base`, and `jackson-module-jakarta-xmlbind-annotations`.

## Test plan
- [ ] Composite check passes (`./gradlew :hivemq-edge-build:check` from `hivemq-edge-composite/`)
- [ ] CI green