### PR TITLE
PLT-524: Add CompositeJenkinsfile

### DIFF
--- a/CompositeJenkinsfile
+++ b/CompositeJenkinsfile
@@ -1,0 +1,35 @@
+MASTER_BRANCH = 'master'
+
+pipeline {
+    agent { label 'jenkins-worker' }
+    options {
+        skipDefaultCheckout() // no checkout needed
+        buildDiscarder(logRotator(numToKeepStr: '10'))
+        timestamps()
+    }
+    stages {
+        stage('Trigger build') {
+            steps {
+                script {
+                    def multiBranchJobPath = '../../hivemq-edge-composite'
+                    def branchJobName = BRANCH_NAME.replace('/', '%2F')
+                    try {
+                        build job: "${multiBranchJobPath}/${branchJobName}", wait: false
+                    } catch (e) {
+                        try {
+                            withCredentials([gitUsernamePassword(credentialsId: 'hivemq-jenkins')]) {
+                                sh("git clone https://github.com/hivemq/hivemq-edge-composite.git --branch=${MASTER_BRANCH} --single-branch --depth 1 .")
+                                try {
+                                    sh("git push origin HEAD:${BRANCH_NAME}")
+                                } catch (e2) { // if push failed, branch already exists
+                                }
+                            }
+                        } finally {
+                            cleanWs()
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `CompositeJenkinsfile` mirroring the one in `hivemq-edge`, so pushes to this repo trigger the matching branch build in the `hivemq-edge-composite` multibranch pipeline (and create the branch in `hivemq-edge-composite` if it doesn't exist yet).

Linear: [PLT-524](https://linear.app/hivemq/issue/PLT-524/add-compositejenkinsfile-to-hivemq-edge-sdk-and-module-repos)

## Test plan
- [ ] Push to a feature branch; verify the corresponding `hivemq-edge-composite` branch job is triggered (or created on first push).