### PR TITLE
EDG-720: Add SDK v2 core interfaces, generic actor runtime, and Defau…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,6 +63,13 @@ dependencies {
     compileOnly(libs.jackson.annotations)
     compileOnly(libs.jackson.databind)
     compileOnly(libs.swagger.annotations)
+
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.assertj)
+    testImplementation(libs.awaitility)
+    testImplementation(libs.jackson.databind)
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 /* ******************** java ******************** */
@@ -77,6 +84,10 @@ java {
 
 tasks.withType<JavaCompile>().configureEach {
     options.release.set(21)
+}
+
+tasks.test {
+    useJUnitPlatform()
 }
 
 tasks.withType<Jar>().configureEach {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,9 @@
 [versions]
+assertj = "3.27.7"
+awaitility = "4.3.0"
 jackson= "2.22.0"
 jetbrains-annotations = "24.1.0"
+junit-jupiter = "5.14.4"
 swagger-annotations = "2.2.50"
 victools="4.38.0"
 
@@ -14,9 +17,13 @@ plugin-spotless = "7.2.1"
 
 
 [libraries]
+assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
+awaitility = { module = "org.awaitility:awaitility", version.ref = "awaitility" }
 jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations" }
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
 jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrains-annotations" }
+junit-bom = { module = "org.junit:junit-bom", version.ref = "junit-jupiter" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
 swagger-annotations = { module = "io.swagger.core.v3:swagger-annotations", version.ref = "swagger-annotations" }
 
 

--- a/src/main/java/com/hivemq/adapter/sdk/api2/ProtocolAdapter2.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api2/ProtocolAdapter2.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.adapter.sdk.api2;
+
+import com.hivemq.adapter.sdk.api2.command.BrowseFilter;
+import com.hivemq.adapter.sdk.api2.command.WriteEntry;
+import com.hivemq.adapter.sdk.api2.node.Node;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * The protocol adapter command interface — <b>pure mechanism</b>. The adapter only executes commands and
+ * reports events through {@link ProtocolAdapterCallbacks}; it has ZERO retry, backoff, reconnect, or
+ * scheduling logic — the controlling framework owns all policy.
+ * <p>
+ * Every command is asynchronous and acknowledged by a callback event. Batch variants are always what the
+ * framework calls; how an implementation decomposes a batch is its own concern.
+ * <p>
+ * <b>Long-running commands.</b> An implementation may block its own dispatch thread (a blocking
+ * {@code connect()} against a protocol library is normal); queued commands simply wait, and the framework's
+ * watchdogs bound the damage. A long {@code browse} walk, however, starves polls for its whole duration on a
+ * single-threaded implementation — adapters with large address spaces should implement browse asynchronously
+ * inside the adapter (issue the walk on library threads, report
+ * {@link ProtocolAdapterCallbacks#browseResult(List)} via the thread-safe callbacks).
+ */
+public interface ProtocolAdapter2 {
+
+    /**
+     * @return the identifier of this adapter instance, unique within this Edge instance.
+     */
+    @NotNull String adapterId();
+
+    /**
+     * Start the adapter (allocate resources; no connection yet). Acknowledged by
+     * {@link ProtocolAdapterCallbacks#started()} or
+     * {@link ProtocolAdapterCallbacks#error(com.hivemq.adapter.sdk.api2.command.ErrorScope, String)} with
+     * scope {@code ADAPTER}.
+     */
+    void start();
+
+    /**
+     * Stop the adapter (release resources). Acknowledged by {@link ProtocolAdapterCallbacks#stopped()} or
+     * {@link ProtocolAdapterCallbacks#error(com.hivemq.adapter.sdk.api2.command.ErrorScope, String)} with
+     * scope {@code ADAPTER}.
+     */
+    void stop();
+
+    /**
+     * Connect to the device. Acknowledged by {@link ProtocolAdapterCallbacks#connected()},
+     * {@link ProtocolAdapterCallbacks#error(com.hivemq.adapter.sdk.api2.command.ErrorScope, String)} with
+     * scope {@code CONNECTION}, or {@link ProtocolAdapterCallbacks#disconnected()}.
+     */
+    void connect();
+
+    /**
+     * Disconnect from the device. Acknowledged by {@link ProtocolAdapterCallbacks#disconnected()}.
+     */
+    void disconnect();
+
+    /**
+     * Verify the given nodes against the connected device. Each node is acknowledged by one
+     * {@link ProtocolAdapterCallbacks#verifyResult(Node, com.hivemq.adapter.sdk.api2.command.VerifyOutcome)}.
+     *
+     * @param nodes the nodes to verify.
+     */
+    void verifyBatch(@NotNull List<Node> nodes);
+
+    /**
+     * Poll the current values of the given nodes. Each node is answered by one
+     * {@link ProtocolAdapterCallbacks#dataPoint(Node, com.hivemq.adapter.sdk.api.data.DataPoint)} or one
+     * {@link ProtocolAdapterCallbacks#nodeError(Node, String, boolean)}.
+     *
+     * @param nodes the nodes to poll.
+     */
+    void pollBatch(@NotNull List<Node> nodes);
+
+    /**
+     * Subscribe to value changes of the given nodes. Pushed values arrive as
+     * {@link ProtocolAdapterCallbacks#dataPoint(Node, com.hivemq.adapter.sdk.api.data.DataPoint)}; a failed or
+     * lost subscription is reported as {@link ProtocolAdapterCallbacks#nodeError(Node, String, boolean)}.
+     *
+     * @param nodes the nodes to subscribe to.
+     */
+    void addSubscriptionBatch(@NotNull List<Node> nodes);
+
+    /**
+     * Remove the subscriptions of the given nodes.
+     *
+     * @param nodes the nodes to unsubscribe from.
+     */
+    void removeSubscriptionBatch(@NotNull List<Node> nodes);
+
+    /**
+     * Write the given values southbound. Each entry is acknowledged by one
+     * {@link ProtocolAdapterCallbacks#writeResult(Node, boolean, String)}.
+     *
+     * @param entries the node/value pairs to write.
+     */
+    void writeBatch(@NotNull List<WriteEntry> entries);
+
+    /**
+     * Enumerate the device's address space below the filter node. Answered by one
+     * {@link ProtocolAdapterCallbacks#browseResult(List)}.
+     *
+     * @param filter the filter selecting where to browse.
+     */
+    void browse(@NotNull BrowseFilter filter);
+}

--- a/src/main/java/com/hivemq/adapter/sdk/api2/ProtocolAdapterCallbacks.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api2/ProtocolAdapterCallbacks.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.adapter.sdk.api2;
+
+import com.hivemq.adapter.sdk.api.data.DataPoint;
+import com.hivemq.adapter.sdk.api2.command.BrowseResultEntry;
+import com.hivemq.adapter.sdk.api2.command.ErrorScope;
+import com.hivemq.adapter.sdk.api2.command.VerifyOutcome;
+import com.hivemq.adapter.sdk.api2.node.Node;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * The adapter-to-framework event interface — a tell-façade. Each call is one thread-safe <i>tell</i>: the
+ * framework implements every method by building an immutable event message and enqueueing it on the
+ * controlling actor's mailbox. An adapter may therefore call any callback from any thread (protocol library
+ * callbacks, receive threads, …) with no locking.
+ * <p>
+ * Values are reported keyed by {@link Node} reference — the adapter is not required to set
+ * {@link DataPoint#getTagName()} or {@link DataPoint#getAdapterId()}; the framework stamps them from the
+ * owning node's tag before handing the value to northbound consumers.
+ */
+public interface ProtocolAdapterCallbacks {
+
+    /**
+     * Acknowledges {@link ProtocolAdapter2#start()}.
+     */
+    void started();
+
+    /**
+     * Acknowledges {@link ProtocolAdapter2#stop()}.
+     */
+    void stopped();
+
+    /**
+     * Acknowledges {@link ProtocolAdapter2#connect()}.
+     */
+    void connected();
+
+    /**
+     * Acknowledges {@link ProtocolAdapter2#disconnect()} — or reports a spontaneous connection loss.
+     */
+    void disconnected();
+
+    /**
+     * Reports a failure of the adapter ({@link ErrorScope#ADAPTER}) or of the connection
+     * ({@link ErrorScope#CONNECTION}).
+     *
+     * @param scope  which recovery the failure admits.
+     * @param reason a human-readable description of the failure.
+     */
+    void error(@NotNull ErrorScope scope, @NotNull String reason);
+
+    /**
+     * Reports the outcome of verifying one node of a {@link ProtocolAdapter2#verifyBatch(List)}.
+     *
+     * @param node    the verified node.
+     * @param outcome the verification outcome.
+     */
+    void verifyResult(@NotNull Node node, @NotNull VerifyOutcome outcome);
+
+    /**
+     * Reports one value — a poll response or a subscription push; the {@link Node} is the correlation key.
+     *
+     * @param node  the node the value belongs to.
+     * @param value the reused v1 value; tag name and adapter identifier are stamped by the framework.
+     */
+    void dataPoint(@NotNull Node node, @NotNull DataPoint value);
+
+    /**
+     * Reports a per-node failure (failed poll, failed or lost subscription).
+     *
+     * @param node        the node the failure belongs to.
+     * @param reason      a human-readable description of the failure.
+     * @param spontaneous {@code true} if the failure arrived outside a command-response exchange — this one
+     *                    bit selects the framework's recovery path (retry the operation vs. a full
+     *                    power-cycle of the node's lifecycle).
+     */
+    void nodeError(@NotNull Node node, @NotNull String reason, boolean spontaneous);
+
+    /**
+     * Acknowledges one entry of a {@link ProtocolAdapter2#writeBatch(List)}.
+     *
+     * @param node    the node the write targeted.
+     * @param success whether the write succeeded.
+     * @param reason  a human-readable description of the failure, or {@code null} on success.
+     */
+    void writeResult(@NotNull Node node, boolean success, @Nullable String reason);
+
+    /**
+     * Answers {@link ProtocolAdapter2#browse(com.hivemq.adapter.sdk.api2.command.BrowseFilter)}.
+     *
+     * @param entries the discovered nodes.
+     */
+    void browseResult(@NotNull List<BrowseResultEntry> entries);
+}

--- a/src/main/java/com/hivemq/adapter/sdk/api2/ProtocolAdapterCapability2.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api2/ProtocolAdapterCapability2.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.adapter.sdk.api2;
+
+/**
+ * The optional capabilities a protocol adapter type may declare — exactly the three the framework gates on.
+ * Declared once, on {@link ProtocolAdapterInformation2#capabilities()}.
+ * <p>
+ * There is deliberately no VERIFY capability: verification is always attempted.
+ */
+public enum ProtocolAdapterCapability2 {
+    /**
+     * The adapter can subscribe to value changes ({@link ProtocolAdapter2#addSubscriptionBatch(java.util.List)}
+     * / {@link ProtocolAdapter2#removeSubscriptionBatch(java.util.List)}).
+     */
+    SUBSCRIPTIONS,
+    /**
+     * The adapter can write values southbound ({@link ProtocolAdapter2#writeBatch(java.util.List)}).
+     */
+    WRITE,
+    /**
+     * The adapter can enumerate the device's address space
+     * ({@link ProtocolAdapter2#browse(com.hivemq.adapter.sdk.api2.command.BrowseFilter)}).
+     */
+    BROWSE
+}

--- a/src/main/java/com/hivemq/adapter/sdk/api2/ProtocolAdapterInformation2.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api2/ProtocolAdapterInformation2.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.adapter.sdk.api2;
+
+import com.hivemq.adapter.sdk.api.ProtocolAdapterCategory;
+import com.hivemq.adapter.sdk.api.ProtocolAdapterTag;
+import com.hivemq.adapter.sdk.api2.node.Node;
+import java.util.EnumSet;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Identity, display metadata, and capabilities of a protocol adapter type. This is the <b>single</b> home of
+ * {@link #capabilities()} — the factory deliberately has no capability accessor.
+ * <p>
+ * Category and search tags are the reused v1 enums (reuse boundary, decision D2).
+ */
+public interface ProtocolAdapterInformation2 {
+
+    /**
+     * @return the unique identifier of the protocol this adapter type implements.
+     */
+    @NotNull String protocolId();
+
+    /**
+     * @return the human-readable display name of the adapter type.
+     */
+    @NotNull String displayName();
+
+    /**
+     * @return the human-readable description of the adapter type.
+     */
+    @NotNull String description();
+
+    /**
+     * @return the version of the adapter type.
+     */
+    @NotNull String version();
+
+    /**
+     * @return the URL of the adapter type's logo.
+     */
+    @NotNull String logoUrl();
+
+    /**
+     * @return the author of the adapter type.
+     */
+    @NotNull String author();
+
+    /**
+     * @return the reused v1 category of the adapter type.
+     */
+    @NotNull ProtocolAdapterCategory category();
+
+    /**
+     * @return the reused v1 search tags of the adapter type.
+     */
+    @NotNull List<ProtocolAdapterTag> tags();
+
+    /**
+     * @return the optional capabilities this adapter type declares; the framework gates subscription, write,
+     *         and browse behavior on this set.
+     */
+    @NotNull EnumSet<ProtocolAdapterCapability2> capabilities();
+
+    /**
+     * @return the concrete {@link Node} subclass of this adapter type, for JSON (de)serialization of node
+     *         strings.
+     */
+    @NotNull Class<? extends Node> nodeClass();
+
+    /**
+     * @return the configuration version this adapter type currently writes; v2 framework types report a value
+     *         greater than or equal to {@code 2}. A documented secondary signal — the authoritative
+     *         discriminator between the legacy and v2 subsystems stays the configuration section and the
+     *         factory registry.
+     */
+    int currentConfigVersion();
+}

--- a/src/main/java/com/hivemq/adapter/sdk/api2/actor/Actor.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api2/actor/Actor.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.adapter.sdk.api2.actor;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * The behavior bound to a {@link Mailbox}. {@link #receive(Message)} handles exactly one message at a time and
+ * is never invoked concurrently: the actor's own state therefore needs no locks, as long as it is touched only
+ * from inside {@code receive}.
+ *
+ * @param <MessageType> the message type this actor handles.
+ */
+public interface Actor<MessageType extends Message> {
+
+    /**
+     * Handle exactly one message. Invoked by the {@link Dispatcher} on the actor's single dispatch thread,
+     * never concurrently.
+     *
+     * @param message the next message, drained from the mailbox in priority-band order.
+     */
+    void receive(@NotNull MessageType message);
+}

--- a/src/main/java/com/hivemq/adapter/sdk/api2/actor/ActorHandle.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api2/actor/ActorHandle.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.adapter.sdk.api2.actor;
+
+/**
+ * The handle returned by {@link Dispatcher#attach(Mailbox, Actor)}. Closing it stops the message pumping for
+ * the attached actor; an in-flight {@link Actor#receive(Message)} completes first.
+ */
+public interface ActorHandle extends AutoCloseable {
+
+    @Override
+    void close();
+}

--- a/src/main/java/com/hivemq/adapter/sdk/api2/actor/DefaultMailbox.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api2/actor/DefaultMailbox.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.adapter.sdk.api2.actor;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Default multi-producer / single-consumer priority mailbox. It lives in the SDK so an adapter template needs
+ * no framework dependency; the framework runtime reuses it for its own actors.
+ * <p>
+ * Implementation: one unbounded FIFO queue per {@link MessagePriority} band behind one lock plus condition —
+ * the lock gives a correct blocking take across bands and cross-thread memory visibility; the lock cost is
+ * acceptable at the expected message rates. A lock-free per-band variant behind the same {@link Mailbox}
+ * interface is a documented performance extension point.
+ * <p>
+ * Thread-safety follows the {@link Mailbox} contract: {@link #tell(Message)} from any thread; {@link #poll()},
+ * {@link #awaitNextMessage(long)}, {@link #isEmpty()}, and {@link #size()} only from the owning dispatch
+ * thread.
+ *
+ * @param <MessageType> the message type carried by this mailbox.
+ */
+public final class DefaultMailbox<MessageType extends Message> implements Mailbox<MessageType> {
+
+    private static final @NotNull MessagePriority @NotNull [] PRIORITIES = MessagePriority.values();
+
+    private final @NotNull ReentrantLock lock = new ReentrantLock();
+    private final @NotNull Condition notEmpty = lock.newCondition();
+    private final @NotNull List<ArrayDeque<MessageType>> bands;
+
+    public DefaultMailbox() {
+        final List<ArrayDeque<MessageType>> mutableBands = new ArrayList<>(PRIORITIES.length);
+        for (int i = 0; i < PRIORITIES.length; i++) {
+            mutableBands.add(new ArrayDeque<>());
+        }
+        bands = List.copyOf(mutableBands);
+    }
+
+    @Override
+    public void tell(final @NotNull MessageType message) {
+        lock.lock();
+        try {
+            bands.get(message.priority().ordinal()).addLast(message);
+            notEmpty.signal();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public @Nullable MessageType poll() {
+        lock.lock();
+        try {
+            return pollHighestPriority();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public @Nullable MessageType awaitNextMessage(final long timeoutMillis) throws InterruptedException {
+        lock.lockInterruptibly();
+        try {
+            long remainingNanos = TimeUnit.MILLISECONDS.toNanos(timeoutMillis);
+            while (true) {
+                final MessageType message = pollHighestPriority();
+                if (message != null) {
+                    return message;
+                }
+                if (remainingNanos <= 0L) {
+                    return null;
+                }
+                remainingNanos = notEmpty.awaitNanos(remainingNanos);
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public boolean isEmpty() {
+        lock.lock();
+        try {
+            for (final ArrayDeque<MessageType> band : bands) {
+                if (!band.isEmpty()) {
+                    return false;
+                }
+            }
+            return true;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public int size() {
+        lock.lock();
+        try {
+            int sum = 0;
+            for (final ArrayDeque<MessageType> band : bands) {
+                sum += band.size();
+            }
+            return sum;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Must be called with {@link #lock} held.
+     */
+    private @Nullable MessageType pollHighestPriority() {
+        for (final ArrayDeque<MessageType> band : bands) {
+            final MessageType message = band.pollFirst();
+            if (message != null) {
+                return message;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/hivemq/adapter/sdk/api2/actor/Dispatcher.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api2/actor/Dispatcher.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.adapter.sdk.api2.actor;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Binds a {@link Mailbox} to an {@link Actor} and pumps messages. The dispatcher drains the mailbox and feeds
+ * {@code receive} one message at a time — the mailbox itself never invokes anything.
+ * <p>
+ * Pluggable: production implementations use a dedicated thread per actor that blocks in
+ * {@link Mailbox#awaitNextMessage(long)}; test implementations drain deterministically on the calling thread.
+ */
+public interface Dispatcher {
+
+    /**
+     * Bind the given mailbox to the given actor and start pumping messages.
+     *
+     * @param mailbox       the mailbox to drain; its owner-thread-only methods become the dispatcher's to
+     *                      call.
+     * @param actor         the behavior to feed, one message at a time, never concurrently.
+     * @param <MessageType> the message type shared by mailbox and actor.
+     * @return a handle that stops the pumping when closed.
+     */
+    <MessageType extends Message> @NotNull ActorHandle attach(
+            @NotNull Mailbox<MessageType> mailbox,
+            @NotNull Actor<MessageType> actor);
+}

--- a/src/main/java/com/hivemq/adapter/sdk/api2/actor/Mailbox.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api2/actor/Mailbox.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.adapter.sdk.api2.actor;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * A multi-producer / single-consumer PRIORITY queue. NOT a consumer-invoker: the mailbox is just a queue — it
+ * never takes a consumer and never invokes a handler. A pluggable {@link Dispatcher} drains it and feeds the
+ * {@link Actor}'s {@code receive} one message at a time.
+ * <p>
+ * {@link #tell(Message)} is safe from any thread; all other methods are called ONLY by the owning dispatch
+ * thread.
+ * <p>
+ * <b>ORDERING CONTRACT:</b> delivery is by message-type priority ({@link MessagePriority#CONTROL} &gt;
+ * {@link MessagePriority#EVENT} &gt; {@link MessagePriority#TICK} &gt; {@link MessagePriority#DATA}); WITHIN
+ * one band the mailbox is FIFO — a producer's emit order is its delivery order inside that band. All protocol
+ * adapter lifecycle events share the {@code EVENT} band, which is what makes "a late {@code connected()}
+ * cannot overtake the {@code disconnected()} that followed it" true by construction.
+ *
+ * @param <MessageType> the message type carried by this mailbox.
+ */
+public interface Mailbox<MessageType extends Message> extends MailboxSender<MessageType> {
+
+    /**
+     * Owner thread only. Non-blocking.
+     *
+     * @return the highest-priority message available, or {@code null} when the mailbox is empty.
+     */
+    @Nullable MessageType poll();
+
+    /**
+     * Blocking receive for thread-per-actor dispatchers. Owner thread only.
+     * <p>
+     * This is the wakeup contract: a {@link #tell(Message)} from any thread releases a waiting owner.
+     *
+     * @param timeoutMillis how long to wait for a message before giving up, in milliseconds.
+     * @return the highest-priority message available, or {@code null} on timeout.
+     * @throws InterruptedException if the owning dispatch thread is interrupted while waiting.
+     */
+    @Nullable MessageType awaitNextMessage(long timeoutMillis) throws InterruptedException;
+
+    /**
+     * Owner thread only.
+     *
+     * @return whether every priority band is empty.
+     */
+    boolean isEmpty();
+
+    /**
+     * Owner thread only.
+     *
+     * @return the approximate number of queued messages, summed across all priority bands; feeds the mailbox
+     *         depth metric.
+     */
+    int size();
+}

--- a/src/main/java/com/hivemq/adapter/sdk/api2/actor/MailboxSender.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api2/actor/MailboxSender.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.adapter.sdk.api2.actor;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Send-only, thread-safe handle — the actor-model "tell" capability. This is the ONLY capability producers
+ * hold: a producer cannot poll, cannot read actor state, and cannot reach the {@link Actor}.
+ *
+ * @param <MessageType> the message type accepted by the underlying mailbox.
+ */
+public interface MailboxSender<MessageType extends Message> {
+
+    /**
+     * Enqueue one message. Thread-safe, non-blocking, fire-and-forget: callable from ANY thread.
+     *
+     * @param message the immutable message to enqueue; ownership transfers with the call.
+     */
+    void tell(@NotNull MessageType message);
+}

--- a/src/main/java/com/hivemq/adapter/sdk/api2/actor/Message.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api2/actor/Message.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.adapter.sdk.api2.actor;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Marker for anything that may be placed in a {@link Mailbox}. Implementations MUST be immutable: ownership
+ * transfers with the {@link MailboxSender#tell(Message) tell}, and the message is read on a different thread
+ * than the one that created it.
+ * <p>
+ * This is an ordinary, non-sealed interface on purpose: each actor's sealed message hierarchy lives in that
+ * actor's own package (a {@code sealed} interface and its {@code permits} subtypes must share a package) and
+ * extends this marker across packages freely.
+ */
+public interface Message {
+
+    /**
+     * The delivery band — a property of the type, never of the instance. Defaults to
+     * {@link MessagePriority#EVENT}.
+     *
+     * @return the {@link MessagePriority} band this message type is delivered in.
+     */
+    default @NotNull MessagePriority priority() {
+        return MessagePriority.EVENT;
+    }
+}

--- a/src/main/java/com/hivemq/adapter/sdk/api2/actor/MessagePriority.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api2/actor/MessagePriority.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.adapter.sdk.api2.actor;
+
+/**
+ * The mailbox delivery bands, highest priority first.
+ * <p>
+ * The band is a property of the <b>message type</b> — every message type maps to exactly one band; the ladder,
+ * not producer timing, decides cross-band delivery order. Within one band the mailbox is FIFO (see
+ * {@link Mailbox}).
+ * <p>
+ * Why each band sits where it does:
+ * <ul>
+ * <li>{@link #CONTROL} above everything — operator and supervisor intent is never starved by device traffic.
+ * Jumping the queue is always safe by construction: goal and lifecycle commands are valid in every state of the
+ * receiving state machine and bypass its transition table, so early delivery can never cause a defensive
+ * reset.</li>
+ * <li>{@link #EVENT} above {@link #TICK} — an acknowledgment already enqueued is always processed (and its
+ * watchdog canceled) before the tick that would have fired that watchdog. A watchdog therefore fires only when
+ * the awaited reply truly has not arrived.</li>
+ * <li>{@link #TICK} above {@link #DATA} — time stays on time under data floods: watchdogs, backoff, poll
+ * schedules, and batch dispatch are never pushed behind a chatty device's backlog of data points.</li>
+ * <li>{@link #DATA} lowest — the only high-volume band, and the one whose stale messages are harmless: state
+ * machines absorb late data points and browse results in non-collecting states.</li>
+ * </ul>
+ */
+public enum MessagePriority {
+    /**
+     * Goal and lifecycle commands — operator/supervisor intent. Always safe to deliver first: goal commands are
+     * valid in every state and bypass the receiving state machine's transition table.
+     */
+    CONTROL,
+    /**
+     * State-machine events: acknowledgments, errors, verification and write results.
+     */
+    EVENT,
+    /**
+     * Tick messages — time itself, delivered as a message.
+     */
+    TICK,
+    /**
+     * Bulk payload: data points, browse results, batch work.
+     */
+    DATA
+}

--- a/src/main/java/com/hivemq/adapter/sdk/api2/actor/package-info.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api2/actor/package-info.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * The generic actor runtime — type-safe, thread-safe primitives with no framework dependency.
+ * <p>
+ * <b>The actor-model contract.</b> An actor is private state plus a single-threaded behavior
+ * ({@link com.hivemq.adapter.sdk.api2.actor.Actor#receive(com.hivemq.adapter.sdk.api2.actor.Message) receive})
+ * fed one message at a time from a {@link com.hivemq.adapter.sdk.api2.actor.Mailbox} by a pluggable
+ * {@link com.hivemq.adapter.sdk.api2.actor.Dispatcher}. Components interact <b>only</b> by telling each other
+ * typed, immutable messages — there is no ask, no blocking on futures inside an actor, and no shared mutable
+ * state. Producers hold only the send-only {@link com.hivemq.adapter.sdk.api2.actor.MailboxSender}: they cannot
+ * poll, cannot read actor state, and cannot reach the actor itself.
+ * <p>
+ * <b>The mailbox is a queue, not a consumer-invoker.</b> It is multi-producer / single-consumer:
+ * {@code tell} is safe from any thread; {@code poll}, {@code awaitNextMessage}, {@code isEmpty}, and
+ * {@code size} belong exclusively to the one dispatch thread the dispatcher runs the actor on.
+ * <p>
+ * <b>The priority ladder.</b> Delivery is by message-type priority —
+ * {@link com.hivemq.adapter.sdk.api2.actor.MessagePriority#CONTROL CONTROL} &gt;
+ * {@link com.hivemq.adapter.sdk.api2.actor.MessagePriority#EVENT EVENT} &gt;
+ * {@link com.hivemq.adapter.sdk.api2.actor.MessagePriority#TICK TICK} &gt;
+ * {@link com.hivemq.adapter.sdk.api2.actor.MessagePriority#DATA DATA} — and FIFO within each band: a
+ * producer's emit order is its delivery order inside a band. The band is declared once, on the message type,
+ * never per instance.
+ * <p>
+ * {@link com.hivemq.adapter.sdk.api2.actor.DefaultMailbox} is the SDK's concrete mailbox, so that adapter
+ * templates need no framework dependency; the framework runtime reuses it for its own actors.
+ */
+package com.hivemq.adapter.sdk.api2.actor;

--- a/src/main/java/com/hivemq/adapter/sdk/api2/command/BrowseFilter.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api2/command/BrowseFilter.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.adapter.sdk.api2.command;
+
+import com.hivemq.adapter.sdk.api2.node.Node;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * The filter of a browse command: the node to browse below. An "empty" node (one carrying no identity) is a
+ * valid filter and addresses the root of the device's address space.
+ *
+ * @param filterNode the node whose children are to be enumerated.
+ */
+public record BrowseFilter(@NotNull Node filterNode) {
+}

--- a/src/main/java/com/hivemq/adapter/sdk/api2/command/BrowseResultEntry.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api2/command/BrowseResultEntry.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.adapter.sdk.api2.command;
+
+import com.hivemq.adapter.sdk.api.discovery.NodeType;
+import com.hivemq.adapter.sdk.api2.node.Node;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * One entry of a browse result. The node kind is the reused v1 {@link NodeType}.
+ *
+ * @param node       the discovered node.
+ * @param type       the kind of node (folder, object, or value).
+ * @param selectable whether the node can be selected as a tag's node definition.
+ */
+public record BrowseResultEntry(@NotNull Node node, @NotNull NodeType type, boolean selectable) {
+}

--- a/src/main/java/com/hivemq/adapter/sdk/api2/command/ErrorScope.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api2/command/ErrorScope.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.adapter.sdk.api2.command;
+
+/**
+ * The scope of an adapter-reported error: it decides which recovery the framework attempts.
+ */
+public enum ErrorScope {
+    /**
+     * The adapter itself failed — not recoverable by reconnecting.
+     */
+    ADAPTER,
+    /**
+     * The connection failed — recoverable by the framework's reconnect policy.
+     */
+    CONNECTION
+}

--- a/src/main/java/com/hivemq/adapter/sdk/api2/command/VerifyOutcome.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api2/command/VerifyOutcome.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.adapter.sdk.api2.command;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * The outcome of verifying one node against the connected device. Sealed: exactly these three outcomes exist,
+ * so consumers switch exhaustively without a {@code default} branch.
+ */
+public sealed interface VerifyOutcome {
+
+    /**
+     * The node was verified successfully.
+     */
+    record Success() implements VerifyOutcome {
+    }
+
+    /**
+     * Verification failed for a reason that may resolve by itself — the framework retries after a delay.
+     *
+     * @param reason a human-readable description of the failure.
+     */
+    record TransientFailure(@NotNull String reason) implements VerifyOutcome {
+    }
+
+    /**
+     * Verification failed permanently — the framework suspends the tag until a user-commanded retry or a
+     * configuration fix.
+     *
+     * @param reason a human-readable description of the failure.
+     */
+    record PermanentFailure(@NotNull String reason) implements VerifyOutcome {
+    }
+}

--- a/src/main/java/com/hivemq/adapter/sdk/api2/command/WriteEntry.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api2/command/WriteEntry.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.adapter.sdk.api2.command;
+
+import com.hivemq.adapter.sdk.api.data.DataPoint;
+import com.hivemq.adapter.sdk.api2.node.Node;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * One entry of a write batch: the target node and the southbound value to write. The value is the reused v1
+ * {@link DataPoint}.
+ *
+ * @param node  the node to write to.
+ * @param value the value to write.
+ */
+public record WriteEntry(@NotNull Node node, @NotNull DataPoint value) {
+}

--- a/src/main/java/com/hivemq/adapter/sdk/api2/command/package-info.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api2/command/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Value types crossing the protocol-adapter command/event boundary: write entries, browse filters and results,
+ * error scopes, and verification outcomes.
+ * <p>
+ * Values reuse the v1 types where they exist (reuse boundary, decision D2): a southbound value is the reused
+ * {@link com.hivemq.adapter.sdk.api.data.DataPoint}; a browse entry's node kind is the reused
+ * {@link com.hivemq.adapter.sdk.api.discovery.NodeType}.
+ */
+package com.hivemq.adapter.sdk.api2.command;

--- a/src/main/java/com/hivemq/adapter/sdk/api2/factory/ProtocolAdapterFactory2.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api2/factory/ProtocolAdapterFactory2.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.adapter.sdk.api2.factory;
+
+import com.hivemq.adapter.sdk.api.schema.Schema;
+import com.hivemq.adapter.sdk.api2.ProtocolAdapter2;
+import com.hivemq.adapter.sdk.api2.ProtocolAdapterCallbacks;
+import com.hivemq.adapter.sdk.api2.ProtocolAdapterInformation2;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * The factory of one protocol adapter type. There is deliberately no capability accessor here —
+ * {@link ProtocolAdapterInformation2} is the single home of capabilities.
+ */
+public interface ProtocolAdapterFactory2 {
+
+    /**
+     * @return the identity, display metadata, and capabilities of this adapter type — the single source.
+     */
+    @NotNull ProtocolAdapterInformation2 information();
+
+    /**
+     * Construct one adapter instance. Synchronous and cheap: no I/O, no connection — connecting is a separate,
+     * framework-commanded step.
+     *
+     * @param input     the instance configuration, nodes, and services.
+     * @param callbacks the tell-façade the new adapter reports its events through.
+     * @return the new, not-yet-started adapter instance.
+     */
+    @NotNull ProtocolAdapter2 createAdapter(
+            @NotNull ProtocolAdapterInput2 input,
+            @NotNull ProtocolAdapterCallbacks callbacks);
+
+    /**
+     * @return the reused v1 {@link Schema} describing this adapter type's instance configuration.
+     */
+    @NotNull Schema adapterConfigSchema();
+
+    /**
+     * @return the reused v1 {@link Schema} describing this adapter type's node definitions.
+     */
+    @NotNull Schema nodeDefinitionSchema();
+}

--- a/src/main/java/com/hivemq/adapter/sdk/api2/factory/ProtocolAdapterInput2.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api2/factory/ProtocolAdapterInput2.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.adapter.sdk.api2.factory;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.hivemq.adapter.sdk.api2.node.NodeTagPair;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Everything one adapter instance is constructed from.
+ */
+public interface ProtocolAdapterInput2 {
+
+    /**
+     * @return the identifier of the adapter instance, unique within this Edge instance.
+     */
+    @NotNull String adapterId();
+
+    /**
+     * @return the instance configuration, validated against
+     *         {@link ProtocolAdapterFactory2#adapterConfigSchema()}.
+     */
+    @NotNull JsonNode adapterConfig();
+
+    /**
+     * @return the Node/Tag pairs this instance serves.
+     */
+    @NotNull List<NodeTagPair> nodes();
+
+    /**
+     * @return the services the framework provides to the instance.
+     */
+    @NotNull ProtocolAdapterServices2 services();
+}

--- a/src/main/java/com/hivemq/adapter/sdk/api2/factory/ProtocolAdapterServices2.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api2/factory/ProtocolAdapterServices2.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.adapter.sdk.api2.factory;
+
+import com.hivemq.adapter.sdk.api.factories.DataPointFactory;
+import com.hivemq.adapter.sdk.api2.actor.Dispatcher;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * The services the framework provides to an adapter instance.
+ */
+public interface ProtocolAdapterServices2 {
+
+    /**
+     * @return the reused v1 factory adapter code builds its values with.
+     */
+    @NotNull DataPointFactory dataPointFactory();
+
+    /**
+     * @return the dispatcher an actor-based adapter attaches its mailbox to (single-threaded behavior). An
+     *         author who needs a different threading model supplies a different {@link Dispatcher}.
+     */
+    @NotNull Dispatcher dispatcher();
+}

--- a/src/main/java/com/hivemq/adapter/sdk/api2/factory/package-info.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api2/factory/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * The factory trio: {@link com.hivemq.adapter.sdk.api2.factory.ProtocolAdapterFactory2} constructs adapter
+ * instances from a {@link com.hivemq.adapter.sdk.api2.factory.ProtocolAdapterInput2}, which carries the
+ * {@link com.hivemq.adapter.sdk.api2.factory.ProtocolAdapterServices2} the framework provides.
+ * <p>
+ * Capabilities live solely on {@link com.hivemq.adapter.sdk.api2.ProtocolAdapterInformation2}; instance
+ * construction is synchronous and cheap (no I/O, no connection).
+ */
+package com.hivemq.adapter.sdk.api2.factory;

--- a/src/main/java/com/hivemq/adapter/sdk/api2/node/AccessFlags.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api2/node/AccessFlags.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.adapter.sdk.api2.node;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * The declared access capabilities of a node.
+ *
+ * @param readable     whether the node's value can be read at all.
+ * @param writable     whether the node's value can be written.
+ * @param pollable     whether the value can be polled; meaningful only if {@code readable} is
+ *                     {@link AccessTriState#YES}.
+ * @param subscribable whether the value can be subscribed to; meaningful only if {@code readable} is
+ *                     {@link AccessTriState#YES}.
+ */
+public record AccessFlags(
+        @NotNull AccessTriState readable,
+        @NotNull AccessTriState writable,
+        @NotNull AccessTriState pollable,
+        @NotNull AccessTriState subscribable) {
+}

--- a/src/main/java/com/hivemq/adapter/sdk/api2/node/AccessTriState.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api2/node/AccessTriState.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.adapter.sdk.api2.node;
+
+/**
+ * Three-valued access capability of a node, as declared in {@link AccessFlags}.
+ */
+public enum AccessTriState {
+    /**
+     * The capability is available.
+     */
+    YES,
+    /**
+     * The capability is not available.
+     */
+    NO,
+    /**
+     * The capability may be available on the device, but the configuration declares it unused.
+     */
+    WILL_NOT_USE
+}

--- a/src/main/java/com/hivemq/adapter/sdk/api2/node/Node.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api2/node/Node.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.adapter.sdk.api2.node;
+
+import java.util.EnumSet;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * The protocol-specific half of the inseparable Node/Tag pair — a passive data object, subclassed per
+ * protocol. The protocol adapter sees {@code Node} ONLY: it never sees {@link Tag2}, mappings, or anything on
+ * the Edge side. Correlation across the adapter boundary is by {@code Node} reference — there is no lookup map
+ * anywhere.
+ */
+public abstract class Node {
+
+    /**
+     * @return the minimum identity of this node (present on {@link NodeProperty#UNIQUE} nodes).
+     */
+    public abstract @NotNull String nodeId();
+
+    /**
+     * @return the full JSON serialization of this node definition (always present).
+     */
+    public abstract @NotNull String nodeString();
+
+    /**
+     * @return the computed, never-serialized properties of this node.
+     */
+    public abstract @NotNull EnumSet<NodeProperty> properties();
+
+    /**
+     * @param property the property to test for.
+     * @return whether this node has the given computed property.
+     */
+    public final boolean is(final @NotNull NodeProperty property) {
+        return properties().contains(property);
+    }
+}

--- a/src/main/java/com/hivemq/adapter/sdk/api2/node/NodeProperty.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api2/node/NodeProperty.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.adapter.sdk.api2.node;
+
+/**
+ * Computed, never-serialized properties of a {@link Node}.
+ */
+public enum NodeProperty {
+    /**
+     * The node carries enough identity to be addressed unambiguously ({@link Node#nodeId()} is meaningful).
+     */
+    UNIQUE,
+    /**
+     * The node's data type is known.
+     */
+    TYPED,
+    /**
+     * The node definition is internally consistent and complete enough to be used.
+     */
+    VALID
+}

--- a/src/main/java/com/hivemq/adapter/sdk/api2/node/NodeTagPair.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api2/node/NodeTagPair.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.adapter.sdk.api2.node;
+
+import com.hivemq.adapter.sdk.api.schema.Schema;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * The inseparable pair: {@link Node} is the protocol-specific half (the protocol adapter sees this only);
+ * {@link Tag2} is Edge's half. Created together, each holds a direct reference to the other — no lookup map
+ * anywhere.
+ */
+public final class NodeTagPair {
+
+    private final @NotNull Node node;
+    private final @NotNull Tag2 tag;
+
+    private NodeTagPair(final @NotNull Node node, final @NotNull Tag2 tag) {
+        this.node = node;
+        this.tag = tag;
+    }
+
+    /**
+     * Create the pair. This is the only way a {@link Tag2} comes into existence — the pair halves have no
+     * public constructors.
+     *
+     * @param node         the protocol-specific node definition.
+     * @param tagName      the tag name, unique within its adapter.
+     * @param schema       the reused v1 {@link Schema} describing the tag's value shape.
+     * @param pollable     whether the tag's value can be polled.
+     * @param subscribable whether the tag's value can be subscribed to.
+     * @return the new pair, with the {@link Tag2} back-referencing the given {@link Node}.
+     */
+    public static @NotNull NodeTagPair create(
+            final @NotNull Node node,
+            final @NotNull String tagName,
+            final @NotNull Schema schema,
+            final boolean pollable,
+            final boolean subscribable) {
+        return new NodeTagPair(node, new Tag2(tagName, schema, pollable, subscribable, node));
+    }
+
+    /**
+     * @return the protocol-specific half of the pair.
+     */
+    public @NotNull Node node() {
+        return node;
+    }
+
+    /**
+     * @return Edge's half of the pair.
+     */
+    public @NotNull Tag2 tag() {
+        return tag;
+    }
+}

--- a/src/main/java/com/hivemq/adapter/sdk/api2/node/Tag2.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api2/node/Tag2.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.adapter.sdk.api2.node;
+
+import com.hivemq.adapter.sdk.api.schema.Schema;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Edge's half of the inseparable Node/Tag pair. Holds a direct reference to its {@link Node} — there is no
+ * lookup map anywhere. Accessors only; no behavior.
+ * <p>
+ * Named under rule N1 because the v1 SDK ships {@code com.hivemq.adapter.sdk.api.tag.Tag}, a different
+ * config-marker concept.
+ * <p>
+ * Instances are created only through {@link NodeTagPair#create(Node, String, Schema, boolean, boolean)} — the
+ * pair halves have no public constructors.
+ */
+public final class Tag2 {
+
+    private final @NotNull String name;
+    private final @NotNull Schema schema;
+    private final boolean pollable;
+    private final boolean subscribable;
+    private final @NotNull Node node;
+
+    Tag2(
+            final @NotNull String name,
+            final @NotNull Schema schema,
+            final boolean pollable,
+            final boolean subscribable,
+            final @NotNull Node node) {
+        this.name = name;
+        this.schema = schema;
+        this.pollable = pollable;
+        this.subscribable = subscribable;
+        this.node = node;
+    }
+
+    /**
+     * @return the tag name, unique within its adapter.
+     */
+    public @NotNull String name() {
+        return name;
+    }
+
+    /**
+     * @return the reused v1 {@link Schema} describing the tag's value shape, derived from the node's data
+     *         type.
+     */
+    public @NotNull Schema schema() {
+        return schema;
+    }
+
+    /**
+     * @return whether the tag's value can be polled.
+     */
+    public boolean pollable() {
+        return pollable;
+    }
+
+    /**
+     * @return whether the tag's value can be subscribed to.
+     */
+    public boolean subscribable() {
+        return subscribable;
+    }
+
+    /**
+     * @return the protocol-specific half of the pair — the direct back-reference.
+     */
+    public @NotNull Node node() {
+        return node;
+    }
+}

--- a/src/main/java/com/hivemq/adapter/sdk/api2/node/package-info.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api2/node/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * The Node/Tag pair model — the inseparable pair at the heart of the v2 data model.
+ * <p>
+ * {@link com.hivemq.adapter.sdk.api2.node.Node} is the protocol-specific half: a passive data object,
+ * subclassed per protocol, and the ONLY thing a protocol adapter ever sees.
+ * {@link com.hivemq.adapter.sdk.api2.node.Tag2} is Edge's half. The two are created together via
+ * {@link com.hivemq.adapter.sdk.api2.node.NodeTagPair} and each holds a direct reference to the other —
+ * correlation across the adapter boundary is by {@code Node} reference, never by name lookup, and there is no
+ * lookup map anywhere.
+ * <p>
+ * A tag's value shape is the <b>reused</b> v1 {@link com.hivemq.adapter.sdk.api.schema.Schema} — no v2
+ * duplicate exists (reuse boundary, decision D2).
+ */
+package com.hivemq.adapter.sdk.api2.node;

--- a/src/main/java/com/hivemq/adapter/sdk/api2/package-info.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api2/package-info.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * SDK v2 — the contracts a protocol adapter author implements, with no dependency on Edge internals.
+ * <p>
+ * <b>Mechanism vs. policy.</b> A {@link com.hivemq.adapter.sdk.api2.ProtocolAdapter2} is <b>pure
+ * mechanism</b>: it executes commands and reports events through
+ * {@link com.hivemq.adapter.sdk.api2.ProtocolAdapterCallbacks}. It has ZERO retry, backoff, reconnect, or
+ * scheduling logic — the controlling framework owns all policy. Every command is asynchronous and acknowledged
+ * by a callback event.
+ * <p>
+ * <b>The actor-model contract.</b> The callbacks interface is a tell-façade: each call is one thread-safe
+ * <i>tell</i> onto the controlling actor's mailbox — a multi-producer / single-consumer priority queue
+ * (see {@link com.hivemq.adapter.sdk.api2.actor}). Delivery is by message-type priority
+ * ({@code CONTROL} &gt; {@code EVENT} &gt; {@code TICK} &gt; {@code DATA}), FIFO within a band. Adapter code
+ * may call any callback from any thread with no locking.
+ * <p>
+ * <b>The reuse boundary (decision D2).</b> The protocol-agnostic v1 SDK subset is reused as-is and never
+ * duplicated here: values are {@link com.hivemq.adapter.sdk.api.data.DataPoint} (built with
+ * {@link com.hivemq.adapter.sdk.api.factories.DataPointFactory}), value and configuration shapes are
+ * {@link com.hivemq.adapter.sdk.api.schema.Schema}, browse node kinds are
+ * {@link com.hivemq.adapter.sdk.api.discovery.NodeType}, and adapter metadata uses
+ * {@link com.hivemq.adapter.sdk.api.ProtocolAdapterCategory} and
+ * {@link com.hivemq.adapter.sdk.api.ProtocolAdapterTag}. SDK v1 is not modified.
+ * <p>
+ * <b>Naming rules.</b> N1: {@code 2} is a suffix, never an infix — a v2 type with a v1 counterpart is the v1
+ * name plus a trailing {@code 2}; a genuinely-new type takes no {@code 2}. N2: no abbreviations in any API
+ * name, method signature, or variable name.
+ */
+package com.hivemq.adapter.sdk.api2;

--- a/src/test/java/com/hivemq/adapter/sdk/api2/ContractCompilationSmokeTest.java
+++ b/src/test/java/com/hivemq/adapter/sdk/api2/ContractCompilationSmokeTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.adapter.sdk.api2;
+
+import com.hivemq.adapter.sdk.api2.actor.Actor;
+import com.hivemq.adapter.sdk.api2.actor.Message;
+import com.hivemq.adapter.sdk.api2.actor.MessagePriority;
+import com.hivemq.adapter.sdk.api2.command.BrowseFilter;
+import com.hivemq.adapter.sdk.api2.command.WriteEntry;
+import com.hivemq.adapter.sdk.api2.node.Node;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Compile-only contract smoke: a no-op {@link ProtocolAdapter2} and a no-op {@link Actor} compile against the
+ * SDK alone — the executable proof that the author-facing contracts are self-contained.
+ */
+class ContractCompilationSmokeTest {
+
+    private static final class NoOperationProtocolAdapter implements ProtocolAdapter2 {
+        @Override
+        public @NotNull String adapterId() {
+            return "no-operation";
+        }
+
+        @Override
+        public void start() {
+        }
+
+        @Override
+        public void stop() {
+        }
+
+        @Override
+        public void connect() {
+        }
+
+        @Override
+        public void disconnect() {
+        }
+
+        @Override
+        public void verifyBatch(final @NotNull List<Node> nodes) {
+        }
+
+        @Override
+        public void pollBatch(final @NotNull List<Node> nodes) {
+        }
+
+        @Override
+        public void addSubscriptionBatch(final @NotNull List<Node> nodes) {
+        }
+
+        @Override
+        public void removeSubscriptionBatch(final @NotNull List<Node> nodes) {
+        }
+
+        @Override
+        public void writeBatch(final @NotNull List<WriteEntry> entries) {
+        }
+
+        @Override
+        public void browse(final @NotNull BrowseFilter filter) {
+        }
+    }
+
+    private record TestMessage() implements Message {
+    }
+
+    private static final class NoOperationActor implements Actor<TestMessage> {
+        @Override
+        public void receive(final @NotNull TestMessage message) {
+        }
+    }
+
+    @Test
+    void noOperationProtocolAdapter_compilesAndAnswersItsIdentifier() {
+        final NoOperationProtocolAdapter protocolAdapter = new NoOperationProtocolAdapter();
+        assertThat(protocolAdapter.adapterId()).isEqualTo("no-operation");
+        assertThatCode(() -> {
+            protocolAdapter.start();
+            protocolAdapter.connect();
+            protocolAdapter.pollBatch(List.of());
+            protocolAdapter.disconnect();
+            protocolAdapter.stop();
+        }).doesNotThrowAnyException();
+    }
+
+    @Test
+    void noOperationActor_compilesAndReceivesTheDefaultBandMessage() {
+        final NoOperationActor actor = new NoOperationActor();
+        final TestMessage message = new TestMessage();
+        assertThat(message.priority()).isEqualTo(MessagePriority.EVENT);
+        assertThatCode(() -> actor.receive(message)).doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/com/hivemq/adapter/sdk/api2/ReuseBoundaryTest.java
+++ b/src/test/java/com/hivemq/adapter/sdk/api2/ReuseBoundaryTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.adapter.sdk.api2;
+
+import com.hivemq.adapter.sdk.api.ProtocolAdapterCategory;
+import com.hivemq.adapter.sdk.api.ProtocolAdapterTag;
+import com.hivemq.adapter.sdk.api.data.DataPoint;
+import com.hivemq.adapter.sdk.api.discovery.NodeType;
+import com.hivemq.adapter.sdk.api.factories.DataPointFactory;
+import com.hivemq.adapter.sdk.api.schema.Schema;
+import com.hivemq.adapter.sdk.api2.command.BrowseResultEntry;
+import com.hivemq.adapter.sdk.api2.command.WriteEntry;
+import com.hivemq.adapter.sdk.api2.factory.ProtocolAdapterServices2;
+import com.hivemq.adapter.sdk.api2.node.Tag2;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The reuse boundary (decision D2) and the naming rules (N1/N2): {@code api2} references the reused v1 types
+ * — {@link DataPoint}, {@link Schema}, {@link NodeType}, the category and search-tag enums — and never shadows
+ * them; no new identifier carries an infix {@code 2} or a known abbreviation.
+ */
+class ReuseBoundaryTest {
+
+    private static final Path API2_SOURCE_DIRECTORY =
+            Path.of("src", "main", "java", "com", "hivemq", "adapter", "sdk", "api2");
+
+    /**
+     * Simple names of reused v1 types — a same-named type under {@code api2} would be a fork.
+     */
+    private static final Set<String> REUSED_TYPE_SIMPLE_NAMES = Set.of(
+            "DataPoint",
+            "DataPointFactory",
+            "Schema",
+            "ScalarSchema",
+            "ScalarType",
+            "NodeType",
+            "ProtocolAdapterCategory",
+            "ProtocolAdapterTag");
+
+    /**
+     * Architectural shorthands that must never appear in code identifiers (naming rule N2).
+     */
+    private static final Set<String> FORBIDDEN_ABBREVIATIONS =
+            Set.of("Paw", "Pam", "Paf", "Fsm", "Ctx", "Cfg", "Ack", "Mgr");
+
+    @Test
+    void api2_referencesTheReusedV1Types() throws Exception {
+        assertThat(Tag2.class.getMethod("schema").getReturnType()).isEqualTo(Schema.class);
+        assertThat(WriteEntry.class.getMethod("value").getReturnType()).isEqualTo(DataPoint.class);
+        assertThat(BrowseResultEntry.class.getMethod("type").getReturnType()).isEqualTo(NodeType.class);
+        assertThat(ProtocolAdapterServices2.class.getMethod("dataPointFactory").getReturnType())
+                .isEqualTo(DataPointFactory.class);
+        assertThat(ProtocolAdapterInformation2.class.getMethod("category").getReturnType())
+                .isEqualTo(ProtocolAdapterCategory.class);
+
+        final Type tagsReturnType = ProtocolAdapterInformation2.class.getMethod("tags").getGenericReturnType();
+        assertThat(tagsReturnType).isInstanceOf(ParameterizedType.class);
+        final ParameterizedType parameterizedTagsReturnType = (ParameterizedType) tagsReturnType;
+        assertThat(parameterizedTagsReturnType.getRawType()).isEqualTo(List.class);
+        assertThat(parameterizedTagsReturnType.getActualTypeArguments())
+                .containsExactly(ProtocolAdapterTag.class);
+    }
+
+    @Test
+    void api2_doesNotShadowAnyReusedType() throws IOException {
+        for (final String typeName : api2TopLevelTypeNames()) {
+            assertThat(REUSED_TYPE_SIMPLE_NAMES)
+                    .as("api2 type %s must not fork a reused v1 type", typeName)
+                    .doesNotContain(typeName);
+        }
+    }
+
+    @Test
+    void namingRuleN1_twoIsASuffixNeverAnInfix() throws IOException {
+        for (final String typeName : api2TopLevelTypeNames()) {
+            if (typeName.indexOf('2') >= 0) {
+                assertThat(typeName)
+                        .as("identifier %s must carry '2' only as a suffix (naming rule N1)", typeName)
+                        .matches("[A-Za-z]+2");
+            }
+        }
+    }
+
+    @Test
+    void namingRuleN2_noAbbreviationsInTypeNames() throws IOException {
+        for (final String typeName : api2TopLevelTypeNames()) {
+            for (final String abbreviation : FORBIDDEN_ABBREVIATIONS) {
+                assertThat(typeName)
+                        .as("identifier %s must not contain the abbreviation '%s' (naming rule N2)",
+                                typeName, abbreviation)
+                        .doesNotContain(abbreviation);
+            }
+        }
+    }
+
+    private static List<String> api2TopLevelTypeNames() throws IOException {
+        assertThat(API2_SOURCE_DIRECTORY)
+                .as("the test must run with the project directory as its working directory")
+                .exists();
+        try (final Stream<Path> paths = Files.walk(API2_SOURCE_DIRECTORY)) {
+            return paths.filter(path -> path.getFileName().toString().endsWith(".java"))
+                    .map(path -> path.getFileName().toString().replace(".java", ""))
+                    .filter(typeName -> !typeName.equals("package-info"))
+                    .toList();
+        }
+    }
+}

--- a/src/test/java/com/hivemq/adapter/sdk/api2/actor/DefaultMailboxMpscTest.java
+++ b/src/test/java/com/hivemq/adapter/sdk/api2/actor/DefaultMailboxMpscTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.adapter.sdk.api2.actor;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * The multi-producer / single-consumer contract of {@link DefaultMailbox} on REAL threads — Awaitility only,
+ * never {@code Thread.sleep}. (Scenario S23 at the SDK level.)
+ */
+class DefaultMailboxMpscTest {
+
+    private static final int PRODUCER_COUNT = 8;
+    private static final int MESSAGES_PER_PRODUCER = 250;
+
+    private record TestMessage(int producerIndex, int sequence, @NotNull MessagePriority band)
+            implements Message {
+        @Override
+        public @NotNull MessagePriority priority() {
+            return band;
+        }
+    }
+
+    @Test
+    void concurrentProducers_allMessagesReceivedExactlyOnce_perProducerFifoWithinEachBand() throws Exception {
+        final DefaultMailbox<TestMessage> mailbox = new DefaultMailbox<>();
+        final int expectedTotal = PRODUCER_COUNT * MESSAGES_PER_PRODUCER;
+        final MessagePriority[] priorities = MessagePriority.values();
+
+        final List<TestMessage> received = new ArrayList<>(expectedTotal);
+        final AtomicBoolean consumerDone = new AtomicBoolean(false);
+        final Thread consumer = new Thread(() -> {
+            try {
+                while (received.size() < expectedTotal) {
+                    final TestMessage message = mailbox.awaitNextMessage(10_000);
+                    if (message != null) {
+                        received.add(message);
+                    }
+                }
+            } catch (final InterruptedException interruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            consumerDone.set(true);
+        }, "mailbox-consumer");
+        consumer.start();
+
+        final CountDownLatch startSignal = new CountDownLatch(1);
+        final List<Thread> producers = new ArrayList<>(PRODUCER_COUNT);
+        for (int producerIndex = 0; producerIndex < PRODUCER_COUNT; producerIndex++) {
+            final int fixedProducerIndex = producerIndex;
+            final Thread producer = new Thread(() -> {
+                try {
+                    startSignal.await();
+                } catch (final InterruptedException interruptedException) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+                for (int sequence = 0; sequence < MESSAGES_PER_PRODUCER; sequence++) {
+                    final MessagePriority band = priorities[(fixedProducerIndex + sequence) % priorities.length];
+                    mailbox.tell(new TestMessage(fixedProducerIndex, sequence, band));
+                }
+            }, "mailbox-producer-" + producerIndex);
+            producers.add(producer);
+            producer.start();
+        }
+        startSignal.countDown();
+
+        await().atMost(30, TimeUnit.SECONDS).untilTrue(consumerDone);
+        for (final Thread producer : producers) {
+            producer.join(TimeUnit.SECONDS.toMillis(10));
+        }
+        consumer.join(TimeUnit.SECONDS.toMillis(10));
+
+        // exactly N x M received — no loss, no duplication
+        assertThat(received).hasSize(expectedTotal);
+        final Set<String> distinctMessageKeys = new HashSet<>();
+        for (final TestMessage message : received) {
+            distinctMessageKeys.add(message.producerIndex() + ":" + message.sequence());
+        }
+        assertThat(distinctMessageKeys).hasSize(expectedTotal);
+
+        // per-producer FIFO WITHIN each priority band: a producer's emit order is its delivery order
+        final Map<Integer, EnumMap<MessagePriority, List<Integer>>> sequencesByProducerAndBand = new HashMap<>();
+        for (final TestMessage message : received) {
+            sequencesByProducerAndBand
+                    .computeIfAbsent(message.producerIndex(), key -> new EnumMap<>(MessagePriority.class))
+                    .computeIfAbsent(message.band(), key -> new ArrayList<>())
+                    .add(message.sequence());
+        }
+        for (final EnumMap<MessagePriority, List<Integer>> sequencesByBand : sequencesByProducerAndBand.values()) {
+            for (final List<Integer> sequences : sequencesByBand.values()) {
+                assertThat(sequences).isSorted().doesNotHaveDuplicates();
+            }
+        }
+
+        assertThat(mailbox.isEmpty()).isTrue();
+        assertThat(mailbox.size()).isZero();
+    }
+
+    @Test
+    void awaitNextMessage_wakesOnTellFromAnotherThread() throws Exception {
+        final DefaultMailbox<TestMessage> mailbox = new DefaultMailbox<>();
+        final AtomicReference<TestMessage> receivedMessage = new AtomicReference<>();
+        final AtomicBoolean done = new AtomicBoolean(false);
+
+        final Thread consumer = new Thread(() -> {
+            try {
+                receivedMessage.set(mailbox.awaitNextMessage(TimeUnit.SECONDS.toMillis(30)));
+            } catch (final InterruptedException interruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            done.set(true);
+        }, "blocked-consumer");
+        consumer.start();
+
+        // wait until the consumer is parked inside awaitNextMessage, then tell
+        await().atMost(10, TimeUnit.SECONDS)
+                .until(() -> consumer.getState() == Thread.State.TIMED_WAITING ||
+                        consumer.getState() == Thread.State.WAITING);
+        final TestMessage message = new TestMessage(0, 0, MessagePriority.EVENT);
+        mailbox.tell(message);
+
+        await().atMost(10, TimeUnit.SECONDS).untilTrue(done);
+        consumer.join(TimeUnit.SECONDS.toMillis(10));
+        assertThat(receivedMessage.get()).isSameAs(message);
+    }
+
+    @Test
+    void awaitNextMessage_timesOutCleanly() throws Exception {
+        final DefaultMailbox<TestMessage> mailbox = new DefaultMailbox<>();
+
+        assertThat(mailbox.awaitNextMessage(0)).isNull();
+        assertThat(mailbox.awaitNextMessage(20)).isNull();
+        assertThat(Thread.currentThread().isInterrupted()).isFalse();
+
+        // the mailbox stays fully usable after a timeout
+        final TestMessage message = new TestMessage(0, 0, MessagePriority.EVENT);
+        mailbox.tell(message);
+        assertThat(mailbox.awaitNextMessage(0)).isSameAs(message);
+    }
+}

--- a/src/test/java/com/hivemq/adapter/sdk/api2/actor/MailboxContractTest.java
+++ b/src/test/java/com/hivemq/adapter/sdk/api2/actor/MailboxContractTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.adapter.sdk.api2.actor;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The mailbox is a QUEUE, not a consumer-invoker: it exposes only {@code tell} / {@code poll} /
+ * {@code awaitNextMessage} / {@code isEmpty} / {@code size} and no method that accepts a consumer, handler, or
+ * actor. The {@link Dispatcher} drains, never the mailbox. (Reflection assertion, guarding against the
+ * consumer-invoker anti-pattern sneaking back in.)
+ */
+class MailboxContractTest {
+
+    private static final Set<String> ALLOWED_METHOD_NAMES =
+            Set.of("tell", "poll", "awaitNextMessage", "isEmpty", "size");
+
+    @Test
+    void mailboxInterface_exposesOnlyTheQueueContract() {
+        final Set<String> methodNames = Arrays.stream(Mailbox.class.getMethods())
+                .map(Method::getName)
+                .collect(Collectors.toSet());
+        assertThat(methodNames).isEqualTo(ALLOWED_METHOD_NAMES);
+    }
+
+    @Test
+    void mailboxInterface_hasNoConsumerAcceptingMethod() {
+        for (final Method method : Mailbox.class.getMethods()) {
+            for (final Class<?> parameterType : method.getParameterTypes()) {
+                assertThat(parameterType.getPackageName())
+                        .as("method %s must not accept a functional callback", method.getName())
+                        .isNotEqualTo("java.util.function");
+                assertThat(parameterType)
+                        .as("method %s must not accept an Actor — the Dispatcher drains, never the mailbox",
+                                method.getName())
+                        .isNotEqualTo(Actor.class);
+            }
+        }
+    }
+
+    @Test
+    void defaultMailbox_addsNoPublicMethodsBeyondTheContract() {
+        final Set<String> declaredPublicMethodNames = Arrays.stream(DefaultMailbox.class.getMethods())
+                .filter(method -> method.getDeclaringClass() == DefaultMailbox.class)
+                .map(Method::getName)
+                .collect(Collectors.toSet());
+        assertThat(ALLOWED_METHOD_NAMES).containsAll(declaredPublicMethodNames);
+    }
+
+    @Test
+    void mailboxSender_isTheSendOnlySlice() {
+        final Set<String> methodNames = Arrays.stream(MailboxSender.class.getMethods())
+                .map(Method::getName)
+                .collect(Collectors.toSet());
+        assertThat(methodNames).containsExactly("tell");
+        assertThat(MailboxSender.class).isAssignableFrom(Mailbox.class);
+    }
+}

--- a/src/test/java/com/hivemq/adapter/sdk/api2/actor/MessagePriorityOrderingTest.java
+++ b/src/test/java/com/hivemq/adapter/sdk/api2/actor/MessagePriorityOrderingTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.adapter.sdk.api2.actor;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The priority ladder — {@code CONTROL} &gt; {@code EVENT} &gt; {@code TICK} &gt; {@code DATA}, FIFO within a
+ * band — observed through {@link DefaultMailbox#poll()}.
+ */
+class MessagePriorityOrderingTest {
+
+    private record TestMessage(@NotNull String label, @NotNull MessagePriority band) implements Message {
+        @Override
+        public @NotNull MessagePriority priority() {
+            return band;
+        }
+    }
+
+    @Test
+    void controlToldAfterDataBacklog_isPolledFirst() {
+        final DefaultMailbox<TestMessage> mailbox = new DefaultMailbox<>();
+        for (int i = 0; i < 100; i++) {
+            mailbox.tell(new TestMessage("data-" + i, MessagePriority.DATA));
+        }
+        mailbox.tell(new TestMessage("control", MessagePriority.CONTROL));
+
+        final TestMessage first = mailbox.poll();
+        assertThat(first).isNotNull();
+        assertThat(first.label()).isEqualTo("control");
+    }
+
+    @Test
+    void eventToldAfterTick_isPolledBeforeIt() {
+        final DefaultMailbox<TestMessage> mailbox = new DefaultMailbox<>();
+        mailbox.tell(new TestMessage("tick", MessagePriority.TICK));
+        mailbox.tell(new TestMessage("event", MessagePriority.EVENT));
+
+        final TestMessage first = mailbox.poll();
+        final TestMessage second = mailbox.poll();
+        assertThat(first).isNotNull();
+        assertThat(second).isNotNull();
+        assertThat(first.label()).isEqualTo("event");
+        assertThat(second.label()).isEqualTo("tick");
+    }
+
+    @Test
+    void fullLadder_toldInReverse_isPolledHighestPriorityFirst() {
+        final DefaultMailbox<TestMessage> mailbox = new DefaultMailbox<>();
+        mailbox.tell(new TestMessage("data", MessagePriority.DATA));
+        mailbox.tell(new TestMessage("tick", MessagePriority.TICK));
+        mailbox.tell(new TestMessage("event", MessagePriority.EVENT));
+        mailbox.tell(new TestMessage("control", MessagePriority.CONTROL));
+
+        assertThat(pollLabels(mailbox, 4)).containsExactly("control", "event", "tick", "data");
+        assertThat(mailbox.isEmpty()).isTrue();
+    }
+
+    @Test
+    void equalPriorityMessages_comeOutInTellOrder() {
+        final DefaultMailbox<TestMessage> mailbox = new DefaultMailbox<>();
+        mailbox.tell(new TestMessage("first", MessagePriority.EVENT));
+        mailbox.tell(new TestMessage("second", MessagePriority.EVENT));
+        mailbox.tell(new TestMessage("third", MessagePriority.EVENT));
+
+        assertThat(pollLabels(mailbox, 3)).containsExactly("first", "second", "third");
+    }
+
+    @Test
+    void priority_defaultsToEvent() {
+        final Message message = new Message() {
+        };
+        assertThat(message.priority()).isEqualTo(MessagePriority.EVENT);
+    }
+
+    @Test
+    void sizeAndIsEmpty_sumAcrossBands() {
+        final DefaultMailbox<TestMessage> mailbox = new DefaultMailbox<>();
+        assertThat(mailbox.isEmpty()).isTrue();
+        assertThat(mailbox.size()).isZero();
+
+        mailbox.tell(new TestMessage("control", MessagePriority.CONTROL));
+        mailbox.tell(new TestMessage("data", MessagePriority.DATA));
+        assertThat(mailbox.isEmpty()).isFalse();
+        assertThat(mailbox.size()).isEqualTo(2);
+
+        mailbox.poll();
+        assertThat(mailbox.size()).isEqualTo(1);
+        mailbox.poll();
+        assertThat(mailbox.isEmpty()).isTrue();
+        assertThat(mailbox.poll()).isNull();
+    }
+
+    private static @NotNull String[] pollLabels(final @NotNull DefaultMailbox<TestMessage> mailbox, final int count) {
+        final String[] labels = new String[count];
+        for (int i = 0; i < count; i++) {
+            final TestMessage message = mailbox.poll();
+            assertThat(message).isNotNull();
+            labels[i] = message.label();
+        }
+        return labels;
+    }
+}

--- a/src/test/java/com/hivemq/adapter/sdk/api2/command/VerifyOutcomeTest.java
+++ b/src/test/java/com/hivemq/adapter/sdk/api2/command/VerifyOutcomeTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.adapter.sdk.api2.command;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@link VerifyOutcome} is sealed with exactly three record permits — consumers switch exhaustively without a
+ * {@code default} branch (this test class is itself the compile-time proof).
+ */
+class VerifyOutcomeTest {
+
+    @Test
+    void sealedHierarchy_permitsExactlyThreeRecords() {
+        assertThat(VerifyOutcome.class.isSealed()).isTrue();
+        assertThat(VerifyOutcome.class.getPermittedSubclasses()).containsExactlyInAnyOrder(
+                VerifyOutcome.Success.class,
+                VerifyOutcome.TransientFailure.class,
+                VerifyOutcome.PermanentFailure.class);
+        assertThat(VerifyOutcome.Success.class.isRecord()).isTrue();
+        assertThat(VerifyOutcome.TransientFailure.class.isRecord()).isTrue();
+        assertThat(VerifyOutcome.PermanentFailure.class.isRecord()).isTrue();
+    }
+
+    @Test
+    void exhaustiveSwitchWithoutDefault_coversAllOutcomes() {
+        assertThat(describe(new VerifyOutcome.Success())).isEqualTo("success");
+        assertThat(describe(new VerifyOutcome.TransientFailure("flaky link")))
+                .isEqualTo("transient: flaky link");
+        assertThat(describe(new VerifyOutcome.PermanentFailure("node does not exist")))
+                .isEqualTo("permanent: node does not exist");
+    }
+
+    /**
+     * Compiles WITHOUT a {@code default} branch — the sealed permits are the whole universe.
+     */
+    private static @NotNull String describe(final @NotNull VerifyOutcome outcome) {
+        return switch (outcome) {
+            case VerifyOutcome.Success success -> "success";
+            case VerifyOutcome.TransientFailure transientFailure -> "transient: " + transientFailure.reason();
+            case VerifyOutcome.PermanentFailure permanentFailure -> "permanent: " + permanentFailure.reason();
+        };
+    }
+}

--- a/src/test/java/com/hivemq/adapter/sdk/api2/node/NodeTagPairTest.java
+++ b/src/test/java/com/hivemq/adapter/sdk/api2/node/NodeTagPairTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.adapter.sdk.api2.node;
+
+import com.hivemq.adapter.sdk.api.schema.ScalarSchema;
+import com.hivemq.adapter.sdk.api.schema.ScalarType;
+import com.hivemq.adapter.sdk.api.schema.Schema;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The inseparable pair: created together, cross-referencing, carrying the reused v1 {@link Schema}.
+ */
+class NodeTagPairTest {
+
+    private static final class TestNode extends Node {
+        @Override
+        public @NotNull String nodeId() {
+            return "test-node";
+        }
+
+        @Override
+        public @NotNull String nodeString() {
+            return "{\"identifier\":\"test-node\"}";
+        }
+
+        @Override
+        public @NotNull EnumSet<NodeProperty> properties() {
+            return EnumSet.of(NodeProperty.UNIQUE, NodeProperty.TYPED, NodeProperty.VALID);
+        }
+    }
+
+    @Test
+    void create_buildsTheCrossReferencingPair() {
+        final TestNode node = new TestNode();
+        final Schema schema = new ScalarSchema(ScalarType.STRING, null, null, null, null, false, true, false);
+
+        final NodeTagPair pair = NodeTagPair.create(node, "temperature", schema, true, false);
+
+        assertThat(pair.node()).isSameAs(node);
+        assertThat(pair.tag().node()).isSameAs(node);
+        assertThat(pair.tag().name()).isEqualTo("temperature");
+        assertThat(pair.tag().pollable()).isTrue();
+        assertThat(pair.tag().subscribable()).isFalse();
+    }
+
+    @Test
+    void tag_carriesThePassedReusedSchema() {
+        final Schema schema = new ScalarSchema(ScalarType.DOUBLE, 0, 100, null, null, false, true, true);
+
+        final NodeTagPair pair = NodeTagPair.create(new TestNode(), "pressure", schema, false, true);
+
+        assertThat(pair.tag().schema()).isSameAs(schema);
+    }
+
+    @Test
+    void nodePropertyQuery_delegatesToComputedProperties() {
+        final TestNode node = new TestNode();
+
+        assertThat(node.is(NodeProperty.UNIQUE)).isTrue();
+        assertThat(node.is(NodeProperty.TYPED)).isTrue();
+        assertThat(node.is(NodeProperty.VALID)).isTrue();
+    }
+
+    @Test
+    void pairHalves_haveNoPublicConstructors() {
+        assertThat(Tag2.class.getConstructors()).isEmpty();
+        assertThat(NodeTagPair.class.getConstructors()).isEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

Nevsky Task 1 ([EDG-720](https://linear.app/hivemq/issue/EDG-720)) — establishes the author-facing SDK v2 contracts in `com.hivemq.adapter.sdk.api2`, wired to the reused v1 types (decision D2), following naming rules N1/N2. Targets the epic branch `epic/nevsky-protocol-adapter-v2`.

Design sources: *Project Nevsky — API Design (v02)* §3 + §5.1, *Project Nevsky — Progressive Project Plan (v02)* Task 1.

### New packages

- **`api2.actor`** — the generic actor runtime: `Message` (with the `priority()` type property), `MessagePriority` (the four delivery bands, `CONTROL` > `EVENT` > `TICK` > `DATA`), `MailboxSender` (`tell`), `Mailbox` (a priority queue, FIFO within a band, with the blocking `awaitNextMessage(timeoutMillis)` contract — no consumer parameter), `DefaultMailbox` (unbounded MPSC: four per-band FIFO queues behind one lock + condition; lock-free per-band swap documented as an extension point), `Actor`, `Dispatcher`, `ActorHandle`. `DefaultMailbox` lives in the SDK so the adapter template (Task 3) needs no framework dependency.
- **`api2`** — `ProtocolAdapter2` (pure mechanism; zero retry/backoff/reconnect/scheduling), `ProtocolAdapterCallbacks` (tell-façade; each call is one thread-safe tell), `ProtocolAdapterCapability2` (SUBSCRIPTIONS / WRITE / BROWSE), `ProtocolAdapterInformation2` (the **single** home of `capabilities()`; reuses the v1 category/tag enums).
- **`api2.factory`** — `ProtocolAdapterFactory2` (no `capabilities()` — information owns it), `ProtocolAdapterInput2`, `ProtocolAdapterServices2`.
- **`api2.node`** — `Node`, `Tag2`, `NodeTagPair` (no public constructors on the pair halves), `NodeProperty`, `AccessTriState`, `AccessFlags`.
- **`api2.command`** — `WriteEntry`, `BrowseFilter`, `BrowseResultEntry`, `ErrorScope`, sealed `VerifyOutcome` (exactly three records).
- Package Javadoc covering the mechanism/policy contract, the actor-model contract (MPSC priority mailbox, single consumer, tell-only, the priority ladder and its within-band FIFO ordering), the reuse boundary, and N1/N2.

### Build changes

First test infrastructure for this repo: JUnit 5 / AssertJ / Awaitility added to `libs.versions.toml` (names and versions match the `hivemq-edge` catalog) and `build.gradle.kts` (`useJUnitPlatform`, `junit-platform-launcher` for Gradle 9). SDK v1 sources are untouched.

## Test plan

25 tests, all green via `./gradlew :hivemq-edge-adapter-sdk:check` from the composite:

- `DefaultMailboxMpscTest` — S23 at SDK level: 8 producers × 250 messages on **real threads + Awaitility, no sleep**; exactly N×M received, per-producer FIFO within each priority band, no loss/duplication; `awaitNextMessage` wakes on `tell` and times out cleanly.
- `MessagePriorityOrderingTest` — a `CONTROL` told after a 100-message `DATA` backlog polls first; `EVENT` beats `TICK`; equal-priority FIFO in tell order; `priority()` defaults to `EVENT`.
- `MailboxContractTest` — reflection: the mailbox exposes only `tell`/`poll`/`awaitNextMessage`/`isEmpty`/`size` and no consumer-accepting method.
- `NodeTagPairTest` — cross-referencing pair; `Tag2` carries the passed reused `Schema`; no public constructors on the pair halves.
- `VerifyOutcomeTest` — sealed permits exactly three records; exhaustive switch with no `default`.
- `ReuseBoundaryTest` — `api2` references `DataPoint`/`Schema`/`NodeType`/category enums from `api`; no shadowed type; no identifier with infix `2` or a known abbreviation.
- `ContractCompilationSmokeTest` — a no-op `ProtocolAdapter2` and a no-op `Actor<TestMessage>` compile against the SDK alone.

`javadoc` also builds with zero warnings from the new `api2` sources.