### PR TITLE
EDG-721: Document the Node contract and add a CI check workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,39 @@
+name: CI Check
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Setup Java
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          distribution: 'adopt'
+          java-version: '25'
+
+      - uses: burrunan/gradle-cache-action@4b67497abd37a511d6c1dc6299bdd84ff39f7bf5 # v3.0.2
+        name: Check
+        with:
+          arguments: check
+          gradle-version: wrapper
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@f3a4c8ee80460c780d2932e55fb914138ecaca2c
+        if: always()
+        with:
+          files: |
+            ${{ github.workspace }}/**/build/test-results/**/*.xml

--- a/src/main/java/com/hivemq/adapter/sdk/api2/node/Node.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api2/node/Node.java
@@ -23,6 +23,14 @@ import org.jetbrains.annotations.NotNull;
  * protocol. The protocol adapter sees {@code Node} ONLY: it never sees {@link Tag2}, mappings, or anything on
  * the Edge side. Correlation across the adapter boundary is by {@code Node} reference — there is no lookup map
  * anywhere.
+ * <p>
+ * JACKSON CONTRACT: a node definition travels as JSON. {@link #nodeString()} is the full Jackson
+ * serialization of the subclass's fields, and the framework reads a stored node string back with Jackson
+ * against {@link com.hivemq.adapter.sdk.api2.ProtocolAdapterInformation2#nodeClass()}. Only fields are
+ * serialized: the computed accessors ({@code nodeId()}, {@code nodeString()}, {@code properties()}) are not
+ * bean getters and therefore never appear in the JSON. A node with no fields set is still valid — it
+ * serializes an empty JSON object and is a legitimate browse filter
+ * ({@link com.hivemq.adapter.sdk.api2.command.BrowseFilter} for "browse from the root").
  */
 public abstract class Node {
 
@@ -32,11 +40,20 @@ public abstract class Node {
     public abstract @NotNull String nodeId();
 
     /**
-     * @return the full JSON serialization of this node definition (always present).
+     * @return the full JSON serialization of this node definition (always present, possibly {@code {}}).
      */
     public abstract @NotNull String nodeString();
 
     /**
+     * The properties are COMPUTED from the subclass's fields on every call and are never serialized.
+     * <p>
+     * Property implication: where the protocol implies it, {@link NodeProperty#UNIQUE} ⇒
+     * {@link NodeProperty#TYPED} — an address that pins a node unambiguously often pins its data type as
+     * well (an OPC UA node id resolves to exactly one typed node). Subclasses whose protocol carries that
+     * implication must include {@code TYPED} whenever they report {@code UNIQUE}; protocols where identity
+     * and type are independent (a raw register address with a separately declared type) report the two
+     * properties independently.
+     *
      * @return the computed, never-serialized properties of this node.
      */
     public abstract @NotNull EnumSet<NodeProperty> properties();

--- a/src/test/java/com/hivemq/adapter/sdk/api2/node/NodePropertiesTest.java
+++ b/src/test/java/com/hivemq/adapter/sdk/api2/node/NodePropertiesTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.adapter.sdk.api2.node;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hivemq.adapter.sdk.api2.command.BrowseFilter;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The {@link Node} contract: {@link Node#properties()} is COMPUTED from the subclass's fields (never
+ * serialized), the UNIQUE-implies-TYPED implication holds where the protocol implies it, and
+ * {@link Node#nodeString()} is the Jackson serialization of the fields — an empty node is a valid browse
+ * filter and still serializes a node string.
+ */
+class NodePropertiesTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    /**
+     * A protocol where an address that pins a node also pins its data type — so UNIQUE implies TYPED.
+     * Properties are derived from the fields on every call; the computed accessors are not bean getters and
+     * therefore never appear in the Jackson serialization.
+     */
+    private static final class AddressNode extends Node {
+
+        public @Nullable String address;
+
+        public AddressNode() {
+        }
+
+        private AddressNode(final @Nullable String address) {
+            this.address = address;
+        }
+
+        @Override
+        public @NotNull String nodeId() {
+            return address == null ? "" : address;
+        }
+
+        @Override
+        public @NotNull String nodeString() {
+            try {
+                return OBJECT_MAPPER.writeValueAsString(this);
+            } catch (final JsonProcessingException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+
+        @Override
+        public @NotNull EnumSet<NodeProperty> properties() {
+            if (address == null || address.isEmpty()) {
+                return EnumSet.noneOf(NodeProperty.class);
+            }
+            // the protocol implies the type from the address: UNIQUE => TYPED
+            return EnumSet.of(NodeProperty.UNIQUE, NodeProperty.TYPED, NodeProperty.VALID);
+        }
+    }
+
+    @Test
+    void properties_areDerivedFromTheFields() {
+        final AddressNode addressed = new AddressNode("ns=2;s=Temperature");
+        assertThat(addressed.properties())
+                .containsExactlyInAnyOrder(NodeProperty.UNIQUE, NodeProperty.TYPED, NodeProperty.VALID);
+        assertThat(addressed.is(NodeProperty.UNIQUE)).isTrue();
+
+        final AddressNode unaddressed = new AddressNode(null);
+        assertThat(unaddressed.properties()).isEmpty();
+        assertThat(unaddressed.is(NodeProperty.UNIQUE)).isFalse();
+
+        // properties follow the fields — computed on every call, not captured at construction time
+        unaddressed.address = "ns=2;s=Pressure";
+        assertThat(unaddressed.properties())
+                .containsExactlyInAnyOrder(NodeProperty.UNIQUE, NodeProperty.TYPED, NodeProperty.VALID);
+    }
+
+    @Test
+    void uniqueImpliesTyped_whereTheProtocolImpliesIt() {
+        final AddressNode node = new AddressNode("ns=2;s=Temperature");
+        assertThat(node.is(NodeProperty.UNIQUE)).isTrue();
+        assertThat(node.is(NodeProperty.TYPED)).isTrue();
+    }
+
+    @Test
+    void emptyNode_isAValidBrowseFilter_andSerializesANodeString() throws Exception {
+        final AddressNode empty = new AddressNode();
+
+        final BrowseFilter filter = new BrowseFilter(empty);
+        assertThat(filter.filterNode()).isSameAs(empty);
+
+        final JsonNode parsed = OBJECT_MAPPER.readTree(empty.nodeString());
+        assertThat(parsed.isObject()).isTrue();
+        // computed accessors are not bean getters — only fields are serialized
+        assertThat(parsed.has("nodeId")).isFalse();
+        assertThat(parsed.has("nodeString")).isFalse();
+        assertThat(parsed.has("properties")).isFalse();
+    }
+
+    @Test
+    void nodeString_roundTripsThroughJackson() throws Exception {
+        final AddressNode original = new AddressNode("ns=2;s=Temperature");
+
+        final AddressNode restored = OBJECT_MAPPER.readValue(original.nodeString(), AddressNode.class);
+
+        assertThat(restored.address).isEqualTo(original.address);
+        assertThat(restored.properties()).isEqualTo(original.properties());
+        assertThat(restored.nodeString()).isEqualTo(original.nodeString());
+    }
+}


### PR DESCRIPTION
## Summary

Nevsky Task 2 (EDG-721), SDK half — reuse wiring (Schema + DataPoint) + node properties / strings / projection.

- **Node contract Javadoc**: states the Jackson contract — `nodeString()` is the field-only Jackson serialization of the subclass, read back against `ProtocolAdapterInformation2.nodeClass()`; the computed accessors (`nodeId()`, `nodeString()`, `properties()`) never appear in the JSON; an empty node serializes `{}` and is a valid browse filter. Also states the property implication: `UNIQUE` ⇒ `TYPED` where the protocol implies it.
- **NodePropertiesTest** (4 tests): properties computed from the fields on every call, the UNIQUE-implies-TYPED implication, the empty node as a browse filter, and the Jackson round trip of `nodeString()`.
- **CI**: a GitHub Actions workflow runs the Gradle `check` task on pushes and pull requests and publishes the test results.

The framework half of Task 2 (`DataPointStamping`, `SchemaJsonTest`, `ReuseNoForkTest`) lands in the hivemq-edge repository on the same feature branch.

## Test plan

- `./gradlew :hivemq-edge-adapter-sdk:check` green from the composite (29 tests, 0 failures).
- `javadoc` clean for `api2` (zero warnings).