### PR TITLE
docs(EDG-735): align PA stop() and subscription contract with Design Doc v2

### DIFF
--- a/src/main/java/com/hivemq/adapter/sdk/api/v2/ProtocolAdapter.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/v2/ProtocolAdapter.java
@@ -53,9 +53,11 @@ public interface ProtocolAdapter {
     void start();
 
     /**
-     * Stop the adapter (release resources). Acknowledged by {@link ProtocolAdapterOutput#stopped()} or
-     * {@link ProtocolAdapterOutput#error(com.hivemq.adapter.sdk.api.v2.model.ErrorScope, String)} with
-     * scope {@code ADAPTER}.
+     * Stop the adapter (release resources). <b>Always</b> acknowledged by
+     * {@link ProtocolAdapterOutput#stopped()} — and only by {@code stopped()}: the framework has already
+     * decided to stop, so a partial teardown failure does not change the outcome. Log it and acknowledge
+     * {@code stopped()} anyway. {@code stop()} never reports
+     * {@link ProtocolAdapterOutput#error(com.hivemq.adapter.sdk.api.v2.model.ErrorScope, String)}.
      */
     void stop();
 
@@ -92,13 +94,19 @@ public interface ProtocolAdapter {
      * Subscribe to value changes of the given nodes. Pushed values arrive as
      * {@link ProtocolAdapterOutput#dataPoint(Node, com.hivemq.adapter.sdk.api.data.DataPoint)}; a failed or
      * lost subscription is reported as {@link ProtocolAdapterOutput#nodeError(Node, String, boolean)}.
+     * <p>
+     * The semantics are <b>incremental add</b>: the adapter maintains a shadow set of currently subscribed
+     * nodes and each call <i>adds</i> to it. The framework may call this multiple times; an implementation
+     * must <b>not</b> reset or replace existing subscriptions — only the given nodes are affected.
      *
      * @param nodes the nodes to subscribe to.
      */
     void addSubscriptionBatch(@NotNull List<Node> nodes);
 
     /**
-     * Remove the subscriptions of the given nodes.
+     * Remove the subscriptions of the given nodes — <b>fire and forget</b>: no acknowledgment is expected.
+     * The adapter drops the given nodes from its shadow set and tears down their protocol-level
+     * subscriptions; a node that is not currently subscribed is ignored silently.
      *
      * @param nodes the nodes to unsubscribe from.
      */


### PR DESCRIPTION
## EDG-735 — PA contract conformance (Findings 3 & 4)

Two SDK Javadoc fixes found verifying the `api.v2` PA contract against *Project Nevsky — Design Document (v2)*. **Javadoc only — no behavioral or signature change.**

**Finding 3 — `stop()`:** the design requires `stop()` to *always* ack `stopped()`, never `error()` (a partial teardown failure is logged and still acks `stopped()`). The Javadoc previously said *"`stopped()` or `error()`"*, permitting what the design forbids. Tightened.

**Finding 4 — subscription semantics:** the design's load-bearing contract was missing from the interface — an author reading only the SDK could wrongly reset subscriptions per call. Now documented:
- `addSubscriptionBatch` — **incremental add** (shadow set; must not reset/replace existing subscriptions).
- `removeSubscriptionBatch` — **fire-and-forget**, ignore-unknown-silently, no ack.

Findings 1, 2, 5 are tracked on EDG-735 (doc fix / closed / `Tag` modeling for Sam to weigh). Full verification: EDG-735.