### PR TITLE
feat(EDG-737): two-phase browse contract (paginate + resolve) in SDK v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,10 @@ bin/
 ### VS Code ###
 .vscode/
 
+### Agent tooling ###
+.claude/
+.entire/
+
 ### Mac OS ###
 .DS_Store
 

--- a/src/main/java/com/hivemq/adapter/sdk/api/v2/ProtocolAdapter.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/v2/ProtocolAdapter.java
@@ -145,4 +145,19 @@ public interface ProtocolAdapter {
      * @param continuation the opaque token from the previous page.
      */
     void browseNext(int requestId, @NotNull BrowseContinuation continuation);
+
+    /**
+     * Resolve the device attributes (datatype, access, description) of the given nodes — the RESOLVE half of a
+     * browse. {@link #browse(int, BrowseFilter, int)} DISCOVERs which nodes exist; this reads their attributes so
+     * the framework can build typed tag definitions. Like browse it is <b>pure mechanism</b>: one server
+     * round-trip per call (the framework batches the discovered variables), answered by a single
+     * {@link ProtocolAdapterOutput#readAttributesResult(int, List)} carrying one
+     * {@link com.hivemq.adapter.sdk.api.v2.model.ResolvedAttributes} per node, or by
+     * {@link ProtocolAdapterOutput#browseError(int, String)} on failure. Correlated to its browse by
+     * {@code requestId}.
+     *
+     * @param requestId correlates this resolve with the browse that discovered the nodes.
+     * @param nodes     the discovered nodes whose attributes to resolve.
+     */
+    void readNodeAttributes(int requestId, @NotNull List<Node> nodes);
 }

--- a/src/main/java/com/hivemq/adapter/sdk/api/v2/ProtocolAdapter.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/v2/ProtocolAdapter.java
@@ -17,7 +17,7 @@ package com.hivemq.adapter.sdk.api.v2;
 
 import com.hivemq.adapter.sdk.api.v2.model.BrowseContinuation;
 import com.hivemq.adapter.sdk.api.v2.model.BrowseFilter;
-import com.hivemq.adapter.sdk.api.v2.model.BrowseResultEntry;
+import com.hivemq.adapter.sdk.api.v2.model.BrowseNode;
 import com.hivemq.adapter.sdk.api.v2.model.WriteEntry;
 import com.hivemq.adapter.sdk.api.v2.model.ProtocolAdapterOutput;
 import com.hivemq.adapter.sdk.api.v2.node.Node;

--- a/src/main/java/com/hivemq/adapter/sdk/api/v2/ProtocolAdapter.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/v2/ProtocolAdapter.java
@@ -15,7 +15,9 @@
  */
 package com.hivemq.adapter.sdk.api.v2;
 
+import com.hivemq.adapter.sdk.api.v2.model.BrowseContinuation;
 import com.hivemq.adapter.sdk.api.v2.model.BrowseFilter;
+import com.hivemq.adapter.sdk.api.v2.model.BrowseResultEntry;
 import com.hivemq.adapter.sdk.api.v2.model.WriteEntry;
 import com.hivemq.adapter.sdk.api.v2.model.ProtocolAdapterOutput;
 import com.hivemq.adapter.sdk.api.v2.node.Node;
@@ -32,10 +34,10 @@ import org.jetbrains.annotations.NotNull;
  * <p>
  * <b>Long-running commands.</b> An implementation may block its own dispatch thread (a blocking
  * {@code connect()} against a protocol library is normal); queued commands simply wait, and the framework's
- * watchdogs bound the damage. A long {@code browse} walk, however, starves polls for its whole duration on a
- * single-threaded implementation — adapters with large address spaces should implement browse asynchronously
- * inside the adapter (issue the walk on library threads, report
- * {@link ProtocolAdapterOutput#browseResult(List)} via the thread-safe callbacks).
+ * watchdogs bound the damage. Browse does <b>not</b> walk a whole address space in one command: it is
+ * <b>paginated</b> ({@link #browse(int, BrowseFilter, int)} / {@link #browseNext(int, BrowseContinuation)}),
+ * so each step is a single round-trip and lifecycle ({@code CONTROL}) commands and polls interleave between
+ * pages — a large address space never starves them.
  */
 public interface ProtocolAdapter {
 
@@ -121,10 +123,26 @@ public interface ProtocolAdapter {
     void writeBatch(@NotNull List<WriteEntry> entries);
 
     /**
-     * Enumerate the device's address space below the filter node. Answered by one
-     * {@link ProtocolAdapterOutput#browseResult(List)}.
+     * Begin enumerating the device's address space below the filter node — <b>one page at a time</b>. Answered
+     * by one {@link ProtocolAdapterOutput#browsePage(int, List, BrowseContinuation)} or
+     * {@link ProtocolAdapterOutput#browseError(int, String)}; if that page carries a non-null
+     * {@link BrowseContinuation}, the framework fetches the next page with
+     * {@link #browseNext(int, BrowseContinuation)}. Pagination keeps each step a single round-trip, so a large
+     * address space never starves lifecycle commands or polls.
      *
-     * @param filter the filter selecting where to browse.
+     * @param requestId     correlates this browse's pages and errors.
+     * @param filter        the filter selecting where to browse.
+     * @param maxReferences max entries per page; {@code 0} lets the device decide, {@code >0} forces pagination.
      */
-    void browse(@NotNull BrowseFilter filter);
+    void browse(int requestId, @NotNull BrowseFilter filter, int maxReferences);
+
+    /**
+     * Fetch the next page of an in-progress browse. Answered by one
+     * {@link ProtocolAdapterOutput#browsePage(int, List, BrowseContinuation)} (continuation {@code null} = last
+     * page) or {@link ProtocolAdapterOutput#browseError(int, String)}.
+     *
+     * @param requestId    the browse these pages belong to.
+     * @param continuation the opaque token from the previous page.
+     */
+    void browseNext(int requestId, @NotNull BrowseContinuation continuation);
 }

--- a/src/main/java/com/hivemq/adapter/sdk/api/v2/ProtocolAdapter.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/v2/ProtocolAdapter.java
@@ -160,4 +160,20 @@ public interface ProtocolAdapter {
      * @param nodes     the discovered nodes whose attributes to resolve.
      */
     void readNodeAttributes(int requestId, @NotNull List<Node> nodes);
+
+    /**
+     * Abandon an in-flight browse: the framework calls this when it gives up on a browse (a request deadline or
+     * a lost connection) so the adapter can release any device-side resource the paginated walk holds open —
+     * for OPC-UA, the server continuation point ({@code ReleaseContinuationPoints}). It expects <b>no</b>
+     * answer: any page, attribute result, or error the adapter still emits for {@code requestId} is ignored.
+     * The default does nothing, which is correct for protocols that hold no per-browse server state.
+     * <p>
+     * <b>Browse request contract.</b> The framework runs <b>one browse at a time per adapter</b> and owns the
+     * {@code requestId}, allocating a fresh one per browse and stamping every {@code browse} / {@code browseNext}
+     * / {@code readNodeAttributes} with it. An adapter need not validate the id; it simply echoes it on every
+     * answer so the framework can discard answers from a superseded browse.
+     *
+     * @param requestId the browse to abandon and release.
+     */
+    default void browseCancel(final int requestId) {}
 }

--- a/src/main/java/com/hivemq/adapter/sdk/api/v2/ProtocolAdapterCapability.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/v2/ProtocolAdapterCapability.java
@@ -33,7 +33,7 @@ public enum ProtocolAdapterCapability {
     WRITE,
     /**
      * The adapter can enumerate the device's address space
-     * ({@link ProtocolAdapter#browse(com.hivemq.adapter.sdk.api.v2.model.BrowseFilter)}).
+     * ({@link ProtocolAdapter#browse(int, com.hivemq.adapter.sdk.api.v2.model.BrowseFilter, int)}).
      */
     BROWSE
 }

--- a/src/main/java/com/hivemq/adapter/sdk/api/v2/messaging/command/ProtocolAdapterBatchProcessCommand.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/v2/messaging/command/ProtocolAdapterBatchProcessCommand.java
@@ -26,7 +26,7 @@ import org.jetbrains.annotations.NotNull;
 
 /**
  * The batch and browse commands — delivered in the {@link MailboxMessagePriority#DATA} band, so bulk work
- * yields to lifecycle. Sealed over its seven immutable record commands (list components are defensively copied).
+ * yields to lifecycle. Sealed over its eight immutable record commands (list components are defensively copied).
  */
 public sealed interface ProtocolAdapterBatchProcessCommand extends ProtocolAdapterCommand {
 
@@ -122,5 +122,14 @@ public sealed interface ProtocolAdapterBatchProcessCommand extends ProtocolAdapt
         public ReadNodeAttributes {
             nodes = List.copyOf(nodes);
         }
+    }
+
+    /**
+     * Carries {@link ProtocolAdapter#browseCancel(int)} — abandon an in-flight browse and release any device-side
+     * resource it holds open. No answer is expected.
+     *
+     * @param requestId the browse to abandon and release.
+     */
+    record BrowseCancel(int requestId) implements ProtocolAdapterBatchProcessCommand {
     }
 }

--- a/src/main/java/com/hivemq/adapter/sdk/api/v2/messaging/command/ProtocolAdapterBatchProcessCommand.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/v2/messaging/command/ProtocolAdapterBatchProcessCommand.java
@@ -26,7 +26,7 @@ import org.jetbrains.annotations.NotNull;
 
 /**
  * The batch and browse commands — delivered in the {@link MailboxMessagePriority#DATA} band, so bulk work
- * yields to lifecycle. Sealed over its six immutable record commands (list components are defensively copied).
+ * yields to lifecycle. Sealed over its seven immutable record commands (list components are defensively copied).
  */
 public sealed interface ProtocolAdapterBatchProcessCommand extends ProtocolAdapterCommand {
 
@@ -109,5 +109,18 @@ public sealed interface ProtocolAdapterBatchProcessCommand extends ProtocolAdapt
      */
     record BrowseNext(int requestId, @NotNull BrowseContinuation continuation)
             implements ProtocolAdapterBatchProcessCommand {
+    }
+
+    /**
+     * Carries {@link ProtocolAdapter#readNodeAttributes(int, List)} — the RESOLVE step of a browse.
+     *
+     * @param requestId correlates this resolve with the browse that discovered the nodes.
+     * @param nodes     the discovered nodes whose attributes to resolve.
+     */
+    record ReadNodeAttributes(int requestId, @NotNull List<Node> nodes)
+            implements ProtocolAdapterBatchProcessCommand {
+        public ReadNodeAttributes {
+            nodes = List.copyOf(nodes);
+        }
     }
 }

--- a/src/main/java/com/hivemq/adapter/sdk/api/v2/messaging/command/ProtocolAdapterBatchProcessCommand.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/v2/messaging/command/ProtocolAdapterBatchProcessCommand.java
@@ -17,6 +17,7 @@ package com.hivemq.adapter.sdk.api.v2.messaging.command;
 
 import com.hivemq.adapter.sdk.api.v2.ProtocolAdapter;
 import com.hivemq.adapter.sdk.api.v2.messaging.MailboxMessagePriority;
+import com.hivemq.adapter.sdk.api.v2.model.BrowseContinuation;
 import com.hivemq.adapter.sdk.api.v2.model.BrowseFilter;
 import com.hivemq.adapter.sdk.api.v2.model.WriteEntry;
 import com.hivemq.adapter.sdk.api.v2.node.Node;
@@ -90,10 +91,23 @@ public sealed interface ProtocolAdapterBatchProcessCommand extends ProtocolAdapt
     }
 
     /**
-     * Carries {@link ProtocolAdapter#browse(BrowseFilter)}.
+     * Carries {@link ProtocolAdapter#browse(int, BrowseFilter, int)} — the first page of a browse.
      *
-     * @param filter the filter selecting where to browse.
+     * @param requestId     correlates this browse's pages.
+     * @param filter        the filter selecting where to browse.
+     * @param maxReferences max entries per page; {@code 0} lets the device decide, {@code >0} forces pagination.
      */
-    record Browse(@NotNull BrowseFilter filter) implements ProtocolAdapterBatchProcessCommand {
+    record Browse(int requestId, @NotNull BrowseFilter filter, int maxReferences)
+            implements ProtocolAdapterBatchProcessCommand {
+    }
+
+    /**
+     * Carries {@link ProtocolAdapter#browseNext(int, BrowseContinuation)} — the next page of a browse.
+     *
+     * @param requestId    the browse this page belongs to.
+     * @param continuation the opaque token from the previous page.
+     */
+    record BrowseNext(int requestId, @NotNull BrowseContinuation continuation)
+            implements ProtocolAdapterBatchProcessCommand {
     }
 }

--- a/src/main/java/com/hivemq/adapter/sdk/api/v2/messaging/command/package-info.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/v2/messaging/command/package-info.java
@@ -22,7 +22,7 @@
  * split into the {@link com.hivemq.adapter.sdk.api.v2.messaging.command.ProtocolAdapterConnectionCommand}
  * ({@code CONTROL}) and {@link com.hivemq.adapter.sdk.api.v2.messaging.command.ProtocolAdapterBatchProcessCommand}
  * ({@code DATA}) bands. The value types those commands and their acknowledgements carry — write entries, browse
- * filters and results, error scopes, and verification outcomes — live in
+ * filters and results, resolved attributes, error scopes, and verification outcomes — live in
  * {@link com.hivemq.adapter.sdk.api.v2.model}.
  */
 package com.hivemq.adapter.sdk.api.v2.messaging.command;

--- a/src/main/java/com/hivemq/adapter/sdk/api/v2/model/BrowseContinuation.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/v2/model/BrowseContinuation.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.adapter.sdk.api.v2.model;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * An opaque continuation token for a paginated browse. The adapter produces one on a
+ * {@link ProtocolAdapterOutput#browsePage(int, java.util.List, BrowseContinuation)} when more pages remain,
+ * and the framework hands it back verbatim on
+ * {@link com.hivemq.adapter.sdk.api.v2.ProtocolAdapter#browseNext(int, BrowseContinuation)}. It is opaque to
+ * the framework — the adapter owns the encoding (for example an OPC-UA continuation point, base64-encoded).
+ *
+ * @param token the adapter-owned opaque resume token.
+ */
+public record BrowseContinuation(@NotNull String token) {
+}

--- a/src/main/java/com/hivemq/adapter/sdk/api/v2/model/BrowseNode.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/v2/model/BrowseNode.java
@@ -20,7 +20,7 @@ import com.hivemq.adapter.sdk.api.v2.node.Node;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * One entry of a browse result. The node kind is the reused v1 {@link NodeType}.
+ * A single node discovered by a browse. The node kind is the reused v1 {@link NodeType}.
  * <p>
  * {@code browseName} is the node's human-meaningful name within its parent (for OPC-UA, the BrowseName
  * attribute, e.g. {@code "Temperature"}) — distinct from {@link Node#nodeId()}, which is the machine address.
@@ -33,6 +33,6 @@ import org.jetbrains.annotations.NotNull;
  * @param selectable whether the node can be selected as a tag's node definition.
  * @param browseName the node's name within its parent, used to build paths and default tag names.
  */
-public record BrowseResultEntry(
+public record BrowseNode(
         @NotNull Node node, @NotNull NodeType type, boolean selectable, @NotNull String browseName) {
 }

--- a/src/main/java/com/hivemq/adapter/sdk/api/v2/model/BrowseResultEntry.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/v2/model/BrowseResultEntry.java
@@ -21,10 +21,18 @@ import org.jetbrains.annotations.NotNull;
 
 /**
  * One entry of a browse result. The node kind is the reused v1 {@link NodeType}.
+ * <p>
+ * {@code browseName} is the node's human-meaningful name within its parent (for OPC-UA, the BrowseName
+ * attribute, e.g. {@code "Temperature"}) — distinct from {@link Node#nodeId()}, which is the machine address.
+ * The framework needs it <b>at discovery time</b> to assemble a node's path from its ancestors' browse names
+ * (e.g. {@code /Plant/Line1/Temperature}) and from that a default tag name; this cannot be recovered later,
+ * because the parentage is known only while walking. Empty when the protocol has no such name.
  *
  * @param node       the discovered node.
  * @param type       the kind of node (folder, object, or value).
  * @param selectable whether the node can be selected as a tag's node definition.
+ * @param browseName the node's name within its parent, used to build paths and default tag names.
  */
-public record BrowseResultEntry(@NotNull Node node, @NotNull NodeType type, boolean selectable) {
+public record BrowseResultEntry(
+        @NotNull Node node, @NotNull NodeType type, boolean selectable, @NotNull String browseName) {
 }

--- a/src/main/java/com/hivemq/adapter/sdk/api/v2/model/ProtocolAdapterOutput.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/v2/model/ProtocolAdapterOutput.java
@@ -110,7 +110,7 @@ public interface ProtocolAdapterOutput {
      * @param continuation an opaque token to fetch the next page, or {@code null} if this is the last page.
      */
     void browsePage(
-            int requestId, @NotNull List<BrowseResultEntry> entries, @Nullable BrowseContinuation continuation);
+            int requestId, @NotNull List<BrowseNode> entries, @Nullable BrowseContinuation continuation);
 
     /**
      * Answers {@link ProtocolAdapter#readNodeAttributes(int, List)} — the RESOLVE step of a browse — with the

--- a/src/main/java/com/hivemq/adapter/sdk/api/v2/model/ProtocolAdapterOutput.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/v2/model/ProtocolAdapterOutput.java
@@ -113,9 +113,22 @@ public interface ProtocolAdapterOutput {
             int requestId, @NotNull List<BrowseResultEntry> entries, @Nullable BrowseContinuation continuation);
 
     /**
-     * Reports that a browse failed (for example server throttling or an expired continuation point).
+     * Answers {@link ProtocolAdapter#readNodeAttributes(int, List)} — the RESOLVE step of a browse — with the
+     * device-resolved attributes of the requested nodes, one {@link ResolvedAttributes} per node, reported once
+     * for the whole batch.
      *
-     * @param requestId the browse that failed.
+     * @param requestId  the browse/resolve these attributes belong to.
+     * @param attributes the resolved attributes, one per requested node.
+     */
+    void readAttributesResult(int requestId, @NotNull List<ResolvedAttributes> attributes);
+
+    /**
+     * Reports that a browse step failed — a {@link ProtocolAdapter#browse(int, BrowseFilter, int)} /
+     * {@link ProtocolAdapter#browseNext(int, BrowseContinuation)} page or a
+     * {@link ProtocolAdapter#readNodeAttributes(int, List)} resolve (for example server throttling or an expired
+     * continuation point). Correlated to its request by {@code requestId}.
+     *
+     * @param requestId the browse/resolve that failed.
      * @param reason    a human-readable description of the failure.
      */
     void browseError(int requestId, @NotNull String reason);

--- a/src/main/java/com/hivemq/adapter/sdk/api/v2/model/ProtocolAdapterOutput.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/v2/model/ProtocolAdapterOutput.java
@@ -102,9 +102,21 @@ public interface ProtocolAdapterOutput {
     void writeResult(@NotNull Node node, boolean success, @Nullable String reason);
 
     /**
-     * Answers {@link ProtocolAdapter#browse(com.hivemq.adapter.sdk.api.v2.model.BrowseFilter)}.
+     * Answers one page of {@link ProtocolAdapter#browse(int, BrowseFilter, int)} /
+     * {@link ProtocolAdapter#browseNext(int, BrowseContinuation)}.
      *
-     * @param entries the discovered nodes.
+     * @param requestId    the browse these entries belong to.
+     * @param entries      the discovered nodes in this page.
+     * @param continuation an opaque token to fetch the next page, or {@code null} if this is the last page.
      */
-    void browseResult(@NotNull List<BrowseResultEntry> entries);
+    void browsePage(
+            int requestId, @NotNull List<BrowseResultEntry> entries, @Nullable BrowseContinuation continuation);
+
+    /**
+     * Reports that a browse failed (for example server throttling or an expired continuation point).
+     *
+     * @param requestId the browse that failed.
+     * @param reason    a human-readable description of the failure.
+     */
+    void browseError(int requestId, @NotNull String reason);
 }

--- a/src/main/java/com/hivemq/adapter/sdk/api/v2/model/ResolvedAttributes.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/v2/model/ResolvedAttributes.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.adapter.sdk.api.v2.model;
+
+import com.hivemq.adapter.sdk.api.v2.ProtocolAdapter;
+import com.hivemq.adapter.sdk.api.v2.node.AccessFlags;
+import com.hivemq.adapter.sdk.api.v2.node.Node;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * The device-resolved attributes of one discovered node — the RESOLVE half of a browse. After
+ * {@link ProtocolAdapter#browse(int, BrowseFilter, int)} DISCOVERs the variables, the framework asks the
+ * adapter to RESOLVE their attributes with {@link ProtocolAdapter#readNodeAttributes(int, java.util.List)}; one
+ * of these is reported per resolved node in the answering
+ * {@link ProtocolAdapterOutput#readAttributesResult(int, java.util.List)}.
+ * <p>
+ * {@code dataType} is the protocol's own datatype identifier as a string — the SDK does not impose a
+ * cross-protocol datatype vocabulary; the schema/import layer maps it (for OPC-UA it is the DataType node's
+ * parseable id, e.g. {@code "i=6"} for Int32). {@code access} reuses the SDK's {@link AccessFlags}.
+ *
+ * @param node        the resolved node (the correlation key, as everywhere on the output façade).
+ * @param dataType    the protocol datatype identifier of the node's value.
+ * @param access      the node's declared access capabilities.
+ * @param description a human-readable description of the node, or empty if the device declares none.
+ */
+public record ResolvedAttributes(
+        @NotNull Node node,
+        @NotNull String dataType,
+        @NotNull AccessFlags access,
+        @NotNull String description) {
+}

--- a/src/main/java/com/hivemq/adapter/sdk/api/v2/model/package-info.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/v2/model/package-info.java
@@ -23,6 +23,7 @@
  * to the framework. The boundary value types — {@link com.hivemq.adapter.sdk.api.v2.model.WriteEntry},
  * {@link com.hivemq.adapter.sdk.api.v2.model.BrowseFilter},
  * {@link com.hivemq.adapter.sdk.api.v2.model.BrowseResultEntry},
+ * {@link com.hivemq.adapter.sdk.api.v2.model.ResolvedAttributes},
  * {@link com.hivemq.adapter.sdk.api.v2.model.ErrorScope}, and
  * {@link com.hivemq.adapter.sdk.api.v2.model.VerifyOutcome} — reuse the v1 types where they exist (a southbound
  * value is the reused {@link com.hivemq.adapter.sdk.api.data.DataPoint}; a browse entry's node kind is the

--- a/src/main/java/com/hivemq/adapter/sdk/api/v2/model/package-info.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/v2/model/package-info.java
@@ -22,7 +22,7 @@
  * {@link com.hivemq.adapter.sdk.api.v2.model.ProtocolAdapterOutput} is the adapter's thread-safe tell-façade back
  * to the framework. The boundary value types — {@link com.hivemq.adapter.sdk.api.v2.model.WriteEntry},
  * {@link com.hivemq.adapter.sdk.api.v2.model.BrowseFilter},
- * {@link com.hivemq.adapter.sdk.api.v2.model.BrowseResultEntry},
+ * {@link com.hivemq.adapter.sdk.api.v2.model.BrowseNode},
  * {@link com.hivemq.adapter.sdk.api.v2.model.ResolvedAttributes},
  * {@link com.hivemq.adapter.sdk.api.v2.model.ErrorScope}, and
  * {@link com.hivemq.adapter.sdk.api.v2.model.VerifyOutcome} — reuse the v1 types where they exist (a southbound

--- a/src/main/java/com/hivemq/adapter/sdk/api/v2/node/AccessFlags.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/v2/node/AccessFlags.java
@@ -32,4 +32,49 @@ public record AccessFlags(
         @NotNull AccessTriState writable,
         @NotNull AccessTriState pollable,
         @NotNull AccessTriState subscribable) {
+
+    /**
+     * @return a builder for {@link AccessFlags}. The four capabilities are all {@link AccessTriState} and so are
+     *         trivially transposed when passed positionally to the canonical constructor; the builder names each
+     *         at the call site. Every capability defaults to {@link AccessTriState#NO} until set.
+     */
+    public static @NotNull Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Names each {@link AccessFlags} capability at the call site instead of relying on positional order.
+     */
+    public static final class Builder {
+        private @NotNull AccessTriState readable = AccessTriState.NO;
+        private @NotNull AccessTriState writable = AccessTriState.NO;
+        private @NotNull AccessTriState pollable = AccessTriState.NO;
+        private @NotNull AccessTriState subscribable = AccessTriState.NO;
+
+        private Builder() {}
+
+        public @NotNull Builder readable(final @NotNull AccessTriState readable) {
+            this.readable = readable;
+            return this;
+        }
+
+        public @NotNull Builder writable(final @NotNull AccessTriState writable) {
+            this.writable = writable;
+            return this;
+        }
+
+        public @NotNull Builder pollable(final @NotNull AccessTriState pollable) {
+            this.pollable = pollable;
+            return this;
+        }
+
+        public @NotNull Builder subscribable(final @NotNull AccessTriState subscribable) {
+            this.subscribable = subscribable;
+            return this;
+        }
+
+        public @NotNull AccessFlags build() {
+            return new AccessFlags(readable, writable, pollable, subscribable);
+        }
+    }
 }

--- a/src/main/java/com/hivemq/adapter/sdk/api/v2/template/AbstractProtocolAdapter.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/v2/template/AbstractProtocolAdapter.java
@@ -24,6 +24,7 @@ import com.hivemq.adapter.sdk.api.v2.messaging.MessageHandler;
 import com.hivemq.adapter.sdk.api.v2.messaging.command.ProtocolAdapterBatchProcessCommand;
 import com.hivemq.adapter.sdk.api.v2.messaging.command.ProtocolAdapterCommand;
 import com.hivemq.adapter.sdk.api.v2.messaging.command.ProtocolAdapterConnectionCommand;
+import com.hivemq.adapter.sdk.api.v2.model.BrowseContinuation;
 import com.hivemq.adapter.sdk.api.v2.model.BrowseFilter;
 import com.hivemq.adapter.sdk.api.v2.model.ProtocolAdapterInput;
 import com.hivemq.adapter.sdk.api.v2.model.ProtocolAdapterOutput;
@@ -45,10 +46,10 @@ import org.jetbrains.annotations.NotNull;
  * against a protocol library is normal. Queued commands simply wait behind it, and the framework's watchdogs
  * bound the damage; a queued {@link ProtocolAdapterConnectionCommand.Stop} or
  * {@link ProtocolAdapterConnectionCommand.Disconnect}, being a {@code CONTROL}-band message, is delivered ahead
- * of queued batch work — but nothing can preempt an in-flight {@code do*}. A long {@link #doBrowse(BrowseFilter)}
- * walk starves polls for its whole duration on the template's single thread: adapters with large address spaces
- * should implement browse asynchronously inside the adapter (issue the walk on library threads, report
- * {@link ProtocolAdapterOutput#browseResult(List)} via the thread-safe output).
+ * of queued batch work — but nothing can preempt an in-flight {@code do*}. Browse is paginated
+ * ({@link #doBrowse(int, BrowseFilter, int)} / {@link #doBrowseNext(int, BrowseContinuation)}): each call
+ * returns a single page via {@link ProtocolAdapterOutput#browsePage(int, List, BrowseContinuation)}, so a large
+ * address space yields the dispatch thread between pages and never starves polls or {@code CONTROL} commands.
  * <p>
  * An author who needs a different threading model does not use this template: implement
  * {@link ProtocolAdapter} directly, or supply a different
@@ -140,8 +141,13 @@ public abstract class AbstractProtocolAdapter implements ProtocolAdapter, Messag
     }
 
     @Override
-    public final void browse(final @NotNull BrowseFilter filter) {
-        mailbox.tell(new ProtocolAdapterBatchProcessCommand.Browse(filter));
+    public final void browse(final int requestId, final @NotNull BrowseFilter filter, final int maxReferences) {
+        mailbox.tell(new ProtocolAdapterBatchProcessCommand.Browse(requestId, filter, maxReferences));
+    }
+
+    @Override
+    public final void browseNext(final int requestId, final @NotNull BrowseContinuation continuation) {
+        mailbox.tell(new ProtocolAdapterBatchProcessCommand.BrowseNext(requestId, continuation));
     }
 
     // ── MessageHandler: one message at a time on the dispatch thread ─────────────────────────────
@@ -160,7 +166,10 @@ public abstract class AbstractProtocolAdapter implements ProtocolAdapter, Messag
             case ProtocolAdapterBatchProcessCommand.RemoveSubscriptionBatch removeSubscriptionBatch ->
                     doRemoveSubscriptionBatch(removeSubscriptionBatch.nodes());
             case ProtocolAdapterBatchProcessCommand.WriteBatch writeBatch -> doWriteBatch(writeBatch.entries());
-            case ProtocolAdapterBatchProcessCommand.Browse browse -> doBrowse(browse.filter());
+            case ProtocolAdapterBatchProcessCommand.Browse browse ->
+                    doBrowse(browse.requestId(), browse.filter(), browse.maxReferences());
+            case ProtocolAdapterBatchProcessCommand.BrowseNext browseNext ->
+                    doBrowseNext(browseNext.requestId(), browseNext.continuation());
         }
     }
 
@@ -214,13 +223,27 @@ public abstract class AbstractProtocolAdapter implements ProtocolAdapter, Messag
     // ── Optional no-op defaults ───────────────────────────────────────────────────────────────────
 
     /**
-     * Default: answers an empty browse result — for protocols without an enumerable address space. See the
-     * class Javadoc before implementing a long synchronous walk here.
+     * Default: answers a single empty last page — for protocols without an enumerable address space. Override
+     * to enumerate the filter node's children, returning at most {@code maxReferences} entries and a non-null
+     * {@link BrowseContinuation} when more remain.
      *
-     * @param filter the filter selecting where to browse.
+     * @param requestId     correlates this browse's pages.
+     * @param filter        the filter selecting where to browse.
+     * @param maxReferences max entries per page; {@code 0} lets the device decide, {@code >0} forces pagination.
      */
-    protected void doBrowse(final @NotNull BrowseFilter filter) {
-        output.browseResult(List.of());
+    protected void doBrowse(final int requestId, final @NotNull BrowseFilter filter, final int maxReferences) {
+        output.browsePage(requestId, List.of(), null);
+    }
+
+    /**
+     * Default: answers a single empty last page. Override alongside {@link #doBrowse(int, BrowseFilter, int)}
+     * to resume from the given continuation.
+     *
+     * @param requestId    the browse this page belongs to.
+     * @param continuation the opaque token from the previous page.
+     */
+    protected void doBrowseNext(final int requestId, final @NotNull BrowseContinuation continuation) {
+        output.browsePage(requestId, List.of(), null);
     }
 
     /**

--- a/src/main/java/com/hivemq/adapter/sdk/api/v2/template/AbstractProtocolAdapter.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/v2/template/AbstractProtocolAdapter.java
@@ -157,6 +157,11 @@ public abstract class AbstractProtocolAdapter implements ProtocolAdapter, Messag
         mailbox.tell(new ProtocolAdapterBatchProcessCommand.ReadNodeAttributes(requestId, nodes));
     }
 
+    @Override
+    public final void browseCancel(final int requestId) {
+        mailbox.tell(new ProtocolAdapterBatchProcessCommand.BrowseCancel(requestId));
+    }
+
     // ── MessageHandler: one message at a time on the dispatch thread ─────────────────────────────
 
     @Override
@@ -179,6 +184,8 @@ public abstract class AbstractProtocolAdapter implements ProtocolAdapter, Messag
                     doBrowseNext(browseNext.requestId(), browseNext.continuation());
             case ProtocolAdapterBatchProcessCommand.ReadNodeAttributes readNodeAttributes ->
                     doReadNodeAttributes(readNodeAttributes.requestId(), readNodeAttributes.nodes());
+            case ProtocolAdapterBatchProcessCommand.BrowseCancel browseCancel ->
+                    doBrowseCancel(browseCancel.requestId());
         }
     }
 
@@ -266,6 +273,15 @@ public abstract class AbstractProtocolAdapter implements ProtocolAdapter, Messag
     protected void doReadNodeAttributes(final int requestId, final @NotNull List<Node> nodes) {
         output.readAttributesResult(requestId, List.of());
     }
+
+    /**
+     * Default: does nothing — correct for protocols that hold no per-browse server state. Override alongside
+     * {@link #doBrowse(int, BrowseFilter, int)} to release a device-side resource an abandoned paginated walk
+     * holds open (for OPC-UA, {@code ReleaseContinuationPoints}). No answer is expected.
+     *
+     * @param requestId the browse to abandon and release.
+     */
+    protected void doBrowseCancel(final int requestId) {}
 
     /**
      * Default: reports {@link VerifyOutcome.Success} — for protocols that cannot verify a node ahead of use.

--- a/src/main/java/com/hivemq/adapter/sdk/api/v2/template/AbstractProtocolAdapter.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/v2/template/AbstractProtocolAdapter.java
@@ -49,7 +49,9 @@ import org.jetbrains.annotations.NotNull;
  * of queued batch work — but nothing can preempt an in-flight {@code do*}. Browse is paginated
  * ({@link #doBrowse(int, BrowseFilter, int)} / {@link #doBrowseNext(int, BrowseContinuation)}): each call
  * returns a single page via {@link ProtocolAdapterOutput#browsePage(int, List, BrowseContinuation)}, so a large
- * address space yields the dispatch thread between pages and never starves polls or {@code CONTROL} commands.
+ * address space yields the dispatch thread between pages and never starves polls or {@code CONTROL} commands. The
+ * RESOLVE step ({@link #doReadNodeAttributes(int, List)}) reads the discovered nodes' attributes in the same
+ * {@code DATA} band, one batched round-trip at a time.
  * <p>
  * An author who needs a different threading model does not use this template: implement
  * {@link ProtocolAdapter} directly, or supply a different
@@ -150,6 +152,11 @@ public abstract class AbstractProtocolAdapter implements ProtocolAdapter, Messag
         mailbox.tell(new ProtocolAdapterBatchProcessCommand.BrowseNext(requestId, continuation));
     }
 
+    @Override
+    public final void readNodeAttributes(final int requestId, final @NotNull List<Node> nodes) {
+        mailbox.tell(new ProtocolAdapterBatchProcessCommand.ReadNodeAttributes(requestId, nodes));
+    }
+
     // ── MessageHandler: one message at a time on the dispatch thread ─────────────────────────────
 
     @Override
@@ -170,6 +177,8 @@ public abstract class AbstractProtocolAdapter implements ProtocolAdapter, Messag
                     doBrowse(browse.requestId(), browse.filter(), browse.maxReferences());
             case ProtocolAdapterBatchProcessCommand.BrowseNext browseNext ->
                     doBrowseNext(browseNext.requestId(), browseNext.continuation());
+            case ProtocolAdapterBatchProcessCommand.ReadNodeAttributes readNodeAttributes ->
+                    doReadNodeAttributes(readNodeAttributes.requestId(), readNodeAttributes.nodes());
         }
     }
 
@@ -244,6 +253,18 @@ public abstract class AbstractProtocolAdapter implements ProtocolAdapter, Messag
      */
     protected void doBrowseNext(final int requestId, final @NotNull BrowseContinuation continuation) {
         output.browsePage(requestId, List.of(), null);
+    }
+
+    /**
+     * Default: answers an empty result — for protocols that cannot resolve node attributes. Override alongside
+     * {@link #doBrowse(int, BrowseFilter, int)} to read each node's datatype, access, and description and report
+     * them with {@link ProtocolAdapterOutput#readAttributesResult(int, List)}.
+     *
+     * @param requestId correlates this resolve with the browse that discovered the nodes.
+     * @param nodes     the discovered nodes whose attributes to resolve.
+     */
+    protected void doReadNodeAttributes(final int requestId, final @NotNull List<Node> nodes) {
+        output.readAttributesResult(requestId, List.of());
     }
 
     /**

--- a/src/test/java/com/hivemq/adapter/sdk/api/v2/ContractCompilationSmokeTest.java
+++ b/src/test/java/com/hivemq/adapter/sdk/api/v2/ContractCompilationSmokeTest.java
@@ -15,6 +15,7 @@
  */
 package com.hivemq.adapter.sdk.api.v2;
 
+import com.hivemq.adapter.sdk.api.v2.model.BrowseContinuation;
 import com.hivemq.adapter.sdk.api.v2.model.BrowseFilter;
 import com.hivemq.adapter.sdk.api.v2.model.WriteEntry;
 import com.hivemq.adapter.sdk.api.v2.messaging.MailboxMessage;
@@ -78,7 +79,11 @@ class ContractCompilationSmokeTest {
         }
 
         @Override
-        public void browse(final @NotNull BrowseFilter filter) {
+        public void browse(final int requestId, final @NotNull BrowseFilter filter, final int maxReferences) {
+        }
+
+        @Override
+        public void browseNext(final int requestId, final @NotNull BrowseContinuation continuation) {
         }
     }
 

--- a/src/test/java/com/hivemq/adapter/sdk/api/v2/ContractCompilationSmokeTest.java
+++ b/src/test/java/com/hivemq/adapter/sdk/api/v2/ContractCompilationSmokeTest.java
@@ -85,6 +85,10 @@ class ContractCompilationSmokeTest {
         @Override
         public void browseNext(final int requestId, final @NotNull BrowseContinuation continuation) {
         }
+
+        @Override
+        public void readNodeAttributes(final int requestId, final @NotNull List<Node> nodes) {
+        }
     }
 
     private record TestMessage() implements MailboxMessage {

--- a/src/test/java/com/hivemq/adapter/sdk/api/v2/ReuseBoundaryTest.java
+++ b/src/test/java/com/hivemq/adapter/sdk/api/v2/ReuseBoundaryTest.java
@@ -22,7 +22,7 @@ import com.hivemq.adapter.sdk.api.discovery.NodeType;
 import com.hivemq.adapter.sdk.api.factories.DataPointFactory;
 import com.hivemq.adapter.sdk.api.schema.Schema;
 import com.hivemq.adapter.sdk.api.v2.factories.ProtocolAdapterFactory;
-import com.hivemq.adapter.sdk.api.v2.model.BrowseResultEntry;
+import com.hivemq.adapter.sdk.api.v2.model.BrowseNode;
 import com.hivemq.adapter.sdk.api.v2.model.WriteEntry;
 import com.hivemq.adapter.sdk.api.v2.node.Tag;
 import com.hivemq.adapter.sdk.api.v2.services.ProtocolAdapterService;
@@ -73,7 +73,7 @@ class ReuseBoundaryTest {
     void apiV2_referencesTheReusedV1Types() throws Exception {
         assertThat(Tag.class.getMethod("schema").getReturnType()).isEqualTo(Schema.class);
         assertThat(WriteEntry.class.getMethod("value").getReturnType()).isEqualTo(DataPoint.class);
-        assertThat(BrowseResultEntry.class.getMethod("type").getReturnType()).isEqualTo(NodeType.class);
+        assertThat(BrowseNode.class.getMethod("type").getReturnType()).isEqualTo(NodeType.class);
         assertThat(ProtocolAdapterService.class.getMethod("dataPointFactory").getReturnType())
                 .isEqualTo(DataPointFactory.class);
         assertThat(ProtocolAdapterFactory.class.getMethod("adapterConfigSchema").getReturnType())

--- a/src/test/java/com/hivemq/adapter/sdk/api/v2/template/AbstractProtocolAdapterThreadingTest.java
+++ b/src/test/java/com/hivemq/adapter/sdk/api/v2/template/AbstractProtocolAdapterThreadingTest.java
@@ -87,7 +87,7 @@ class AbstractProtocolAdapterThreadingTest {
         }
 
         @Override
-        protected void doBrowse(final @NotNull BrowseFilter filter) {
+        protected void doBrowse(final int requestId, final @NotNull BrowseFilter filter, final int maxReferences) {
             record("doBrowse:" + filter.filterNode().nodeId());
         }
     }
@@ -116,7 +116,7 @@ class AbstractProtocolAdapterThreadingTest {
         adapter.connect();
         adapter.pollBatch(List.of(new TestNode("node-a")));
         adapter.pollBatch(List.of(new TestNode("node-b")));
-        adapter.browse(new BrowseFilter(new TestNode("root")));
+        adapter.browse(1, new BrowseFilter(new TestNode("root")), 0);
 
         dispatcher.drainAll();
         assertThat(adapter.executed)

--- a/src/test/java/com/hivemq/adapter/sdk/api/v2/template/DefaultNoOpTest.java
+++ b/src/test/java/com/hivemq/adapter/sdk/api/v2/template/DefaultNoOpTest.java
@@ -78,10 +78,10 @@ class DefaultNoOpTest {
         final MinimalAdapter adapter =
                 new MinimalAdapter(TestProtocolAdapterInput.create("adapter-1", dispatcher), callbacks);
 
-        adapter.browse(new BrowseFilter(new TestNode("root")));
+        adapter.browse(7, new BrowseFilter(new TestNode("root")), 0);
 
         dispatcher.drainAll();
-        assertThat(callbacks.invocations()).containsExactly("browseResult");
+        assertThat(callbacks.invocations()).containsExactly("browsePage:7:last");
         assertThat(callbacks.browseResults()).containsExactly(List.of());
     }
 

--- a/src/test/java/com/hivemq/adapter/sdk/api/v2/template/RecordingProtocolAdapterOutput.java
+++ b/src/test/java/com/hivemq/adapter/sdk/api/v2/template/RecordingProtocolAdapterOutput.java
@@ -17,7 +17,7 @@ package com.hivemq.adapter.sdk.api.v2.template;
 
 import com.hivemq.adapter.sdk.api.data.DataPoint;
 import com.hivemq.adapter.sdk.api.v2.model.BrowseContinuation;
-import com.hivemq.adapter.sdk.api.v2.model.BrowseResultEntry;
+import com.hivemq.adapter.sdk.api.v2.model.BrowseNode;
 import com.hivemq.adapter.sdk.api.v2.model.ErrorScope;
 import com.hivemq.adapter.sdk.api.v2.model.ResolvedAttributes;
 import com.hivemq.adapter.sdk.api.v2.model.VerifyOutcome;
@@ -37,7 +37,7 @@ final class RecordingProtocolAdapterOutput implements ProtocolAdapterOutput {
     private final @NotNull List<String> invocations = new ArrayList<>();
     private final @NotNull List<DataPoint> dataPoints = new ArrayList<>();
     private final @NotNull List<VerifyOutcome> verifyOutcomes = new ArrayList<>();
-    private final @NotNull List<List<BrowseResultEntry>> browseResults = new ArrayList<>();
+    private final @NotNull List<List<BrowseNode>> browseResults = new ArrayList<>();
     private final @NotNull List<List<ResolvedAttributes>> resolveResults = new ArrayList<>();
 
     @Override
@@ -90,7 +90,7 @@ final class RecordingProtocolAdapterOutput implements ProtocolAdapterOutput {
     @Override
     public void browsePage(
             final int requestId,
-            final @NotNull List<BrowseResultEntry> entries,
+            final @NotNull List<BrowseNode> entries,
             final @Nullable BrowseContinuation continuation) {
         invocations.add("browsePage:" + requestId + ":" + (continuation == null ? "last" : "more"));
         browseResults.add(entries);
@@ -119,7 +119,7 @@ final class RecordingProtocolAdapterOutput implements ProtocolAdapterOutput {
         return verifyOutcomes;
     }
 
-    @NotNull List<List<BrowseResultEntry>> browseResults() {
+    @NotNull List<List<BrowseNode>> browseResults() {
         return browseResults;
     }
 

--- a/src/test/java/com/hivemq/adapter/sdk/api/v2/template/RecordingProtocolAdapterOutput.java
+++ b/src/test/java/com/hivemq/adapter/sdk/api/v2/template/RecordingProtocolAdapterOutput.java
@@ -16,6 +16,7 @@
 package com.hivemq.adapter.sdk.api.v2.template;
 
 import com.hivemq.adapter.sdk.api.data.DataPoint;
+import com.hivemq.adapter.sdk.api.v2.model.BrowseContinuation;
 import com.hivemq.adapter.sdk.api.v2.model.BrowseResultEntry;
 import com.hivemq.adapter.sdk.api.v2.model.ErrorScope;
 import com.hivemq.adapter.sdk.api.v2.model.VerifyOutcome;
@@ -85,9 +86,17 @@ final class RecordingProtocolAdapterOutput implements ProtocolAdapterOutput {
     }
 
     @Override
-    public void browseResult(final @NotNull List<BrowseResultEntry> entries) {
-        invocations.add("browseResult");
+    public void browsePage(
+            final int requestId,
+            final @NotNull List<BrowseResultEntry> entries,
+            final @Nullable BrowseContinuation continuation) {
+        invocations.add("browsePage:" + requestId + ":" + (continuation == null ? "last" : "more"));
         browseResults.add(entries);
+    }
+
+    @Override
+    public void browseError(final int requestId, final @NotNull String reason) {
+        invocations.add("browseError:" + requestId + ":" + reason);
     }
 
     @NotNull List<String> invocations() {

--- a/src/test/java/com/hivemq/adapter/sdk/api/v2/template/RecordingProtocolAdapterOutput.java
+++ b/src/test/java/com/hivemq/adapter/sdk/api/v2/template/RecordingProtocolAdapterOutput.java
@@ -19,6 +19,7 @@ import com.hivemq.adapter.sdk.api.data.DataPoint;
 import com.hivemq.adapter.sdk.api.v2.model.BrowseContinuation;
 import com.hivemq.adapter.sdk.api.v2.model.BrowseResultEntry;
 import com.hivemq.adapter.sdk.api.v2.model.ErrorScope;
+import com.hivemq.adapter.sdk.api.v2.model.ResolvedAttributes;
 import com.hivemq.adapter.sdk.api.v2.model.VerifyOutcome;
 import com.hivemq.adapter.sdk.api.v2.model.ProtocolAdapterOutput;
 import com.hivemq.adapter.sdk.api.v2.node.Node;
@@ -37,6 +38,7 @@ final class RecordingProtocolAdapterOutput implements ProtocolAdapterOutput {
     private final @NotNull List<DataPoint> dataPoints = new ArrayList<>();
     private final @NotNull List<VerifyOutcome> verifyOutcomes = new ArrayList<>();
     private final @NotNull List<List<BrowseResultEntry>> browseResults = new ArrayList<>();
+    private final @NotNull List<List<ResolvedAttributes>> resolveResults = new ArrayList<>();
 
     @Override
     public void started() {
@@ -95,6 +97,12 @@ final class RecordingProtocolAdapterOutput implements ProtocolAdapterOutput {
     }
 
     @Override
+    public void readAttributesResult(final int requestId, final @NotNull List<ResolvedAttributes> attributes) {
+        invocations.add("readAttributesResult:" + requestId + ":" + attributes.size());
+        resolveResults.add(attributes);
+    }
+
+    @Override
     public void browseError(final int requestId, final @NotNull String reason) {
         invocations.add("browseError:" + requestId + ":" + reason);
     }
@@ -113,5 +121,9 @@ final class RecordingProtocolAdapterOutput implements ProtocolAdapterOutput {
 
     @NotNull List<List<BrowseResultEntry>> browseResults() {
         return browseResults;
+    }
+
+    @NotNull List<List<ResolvedAttributes>> resolveResults() {
+        return resolveResults;
     }
 }


### PR DESCRIPTION
## EDG-737 Finding B — paginated browse contract (draft, for review)

**Proposal** evolving the SDK v2 browse contract toward the FrontEar "desired shape," so a large address space never starves lifecycle (`CONTROL`) commands or polls.

**Before:** `browse(BrowseFilter) → browseResult(List)` — one command; the PA walks the whole address space synchronously on the dispatch thread (Finding B).

**After (paginated):**
- `browse(int requestId, BrowseFilter, int maxReferences)` — first page
- `browseNext(int requestId, BrowseContinuation)` — next page
- `browsePage(int requestId, List<BrowseResultEntry>, @Nullable BrowseContinuation)` — one page; `continuation == null` = last page
- `browseError(int requestId, String)`
- new opaque `BrowseContinuation` (adapter-owned, e.g. base64 OPC-UA continuation point)
- `Browse`/`BrowseNext` commands stay in the **DATA band**, so a queued `CONTROL` command is delivered ahead of the next page — the interleave point the single-shot contract lacked.

Each page is one mailbox round-trip; the framework's PAW drives one page at a time (FrontEar's `BrowseEngine` model). `AbstractProtocolAdapter` + the SDK's own browse tests updated.

**Verified** end-to-end by the OPC-UA conformance test (hivemq-edge PR #1571): a real Milo adapter paginates via continuation points (with a simulated per-page delay), and a `disconnect` fired mid-browse preempts the queued next page.

> **Cross-repo:** the hivemq-edge conformance PR depends on this contract. Locally it resolves via composite substitution (`includeBuild` of the local adapter-sdk); for CI/others this needs to land + publish first. Draft pending review of the contract shape with Sam/Martin.

---

## Update — RESOLVE phase + browse name

The contract now covers the **full two-phase browse** the present Nevsky/Houston spec needs, not just DISCOVER:

- **RESOLVE** — `readNodeAttributes(int requestId, List<Node>)` (DATA band) → `readAttributesResult(int requestId, List<ResolvedAttributes>)`. New `ResolvedAttributes` carries the protocol datatype id (a string — the SDK imposes no cross-protocol datatype vocabulary), the SDK `AccessFlags`, and a description. Shares the `requestId` and the `browseError` channel with DISCOVER.
- **Browse name** — `BrowseResultEntry` now carries `browseName`. The PAW assembles each node's path from its ancestors' browse names *during the walk* (parentage is known only then) and derives a default tag name from it — so the name must ride the discovery entry, not a per-node RESOLVE read. (Closes the gap that previously blocked tag-name defaults.)
- `AbstractProtocolAdapter` gets a default `doReadNodeAttributes`; SDK test doubles updated (`RecordingProtocolAdapterOutput`, `ContractCompilationSmokeTest`).

Full design + diagrams: hivemq-edge PR #1571 (`EDG-737-paginated-browse-design.md`).
