### PR TITLE
EDG-732: Remove an internal tracking reference from a v2 SDK test comment

### DIFF
--- a/src/test/java/com/hivemq/adapter/sdk/api/v2/messaging/DefaultMailboxAdversarialConcurrencyTest.java
+++ b/src/test/java/com/hivemq/adapter/sdk/api/v2/messaging/DefaultMailboxAdversarialConcurrencyTest.java
@@ -38,7 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 /**
- * EDG-734 — independent, adversarial concurrency verification of {@link DefaultMailbox}, deliberately disjoint
+ * Independent, adversarial concurrency verification of {@link DefaultMailbox}, deliberately disjoint
  * from {@code DefaultMailboxMpscTest} (which already proves exactly-once delivery, within-band FIFO, a single
  * wake-on-tell, and clean timeout). This class attacks only what that test leaves open, exclusively on REAL
  * threads, Awaitility only — never {@code Thread.sleep}:


### PR DESCRIPTION
## Open-source hygiene: remove an internal tracking reference

Part of the EDG-732 v2 protocol-adapter work. `DefaultMailboxAdversarialConcurrencyTest`'s class comment cited an internal Linear issue id; since the source is open-sourced, the comment now describes the test in place. Comment-only change (no behavioral or API change).

Companion to the `hivemq-edge` (#1584) and `hivemq-edge-test` (#367) PRs.
