### PR TITLE
EDG-763: Nevsky v2 SDK — tidy a v2 mailbox test comment (code view)

### DIFF
--- a/src/test/java/com/hivemq/adapter/sdk/api/v2/messaging/DefaultMailboxAdversarialConcurrencyTest.java
+++ b/src/test/java/com/hivemq/adapter/sdk/api/v2/messaging/DefaultMailboxAdversarialConcurrencyTest.java
@@ -38,7 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 /**
- * EDG-734 — independent, adversarial concurrency verification of {@link DefaultMailbox}, deliberately disjoint
+ * Independent, adversarial concurrency verification of {@link DefaultMailbox}, deliberately disjoint
  * from {@code DefaultMailboxMpscTest} (which already proves exactly-once delivery, within-band FIFO, a single
  * wake-on-tell, and clean timeout). This class attacks only what that test leaves open, exclusively on REAL
  * threads, Awaitility only — never {@code Thread.sleep}:


### PR DESCRIPTION
## Nevsky Protocol Adapter v2 — adapter SDK (`feat/nevsky-2` → `initiative/nevsky-protocol-adapter-v2`)

Part of the **Nevsky Protocol Adapter FSM Code View** ([EDG-763](https://linear.app/hivemq/issue/EDG-763/nevsky-protocol-adapter-fsm-code-view)).

The v2 adapter-SDK surface (messaging mailbox, v2 node/data model, verification API) already landed on `initiative/nevsky-protocol-adapter-v2`. This PR carries the single remaining delta on `feat/nevsky-2`:

- **EDG-732** — remove an internal tracking reference from a v2 SDK test comment (#102)

**1 file changed, +1 / −1** (`DefaultMailboxAdversarialConcurrencyTest.java`).
