### PR TITLE
EDG-763: Nevsky v2 SDK review round 1 — drop internal design-decision references from api.v2 Javadoc

### DIFF
--- a/src/main/java/com/hivemq/adapter/sdk/api/v2/ProtocolAdapterInformation.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/v2/ProtocolAdapterInformation.java
@@ -26,7 +26,7 @@ import org.jetbrains.annotations.NotNull;
  * Identity, display metadata, and capabilities of a protocol adapter type. This is the <b>single</b> home of
  * {@link #capabilities()} — the factory deliberately has no capability accessor.
  * <p>
- * Category and search tags are the reused v1 enums (reuse boundary, decision D2).
+ * Category and search tags are the reused v1 enums (the reuse boundary).
  */
 public interface ProtocolAdapterInformation {
 

--- a/src/main/java/com/hivemq/adapter/sdk/api/v2/node/package-info.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/v2/node/package-info.java
@@ -24,6 +24,6 @@
  * lookup map anywhere.
  * <p>
  * A tag's value shape is the <b>reused</b> v1 {@link com.hivemq.adapter.sdk.api.schema.Schema} — no v2
- * duplicate exists (reuse boundary, decision D2).
+ * duplicate exists (the reuse boundary).
  */
 package com.hivemq.adapter.sdk.api.v2.node;

--- a/src/main/java/com/hivemq/adapter/sdk/api/v2/package-info.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/v2/package-info.java
@@ -28,7 +28,7 @@
  * ({@code CONTROL} &gt; {@code EVENT} &gt; {@code TICK} &gt; {@code DATA}), FIFO within a band. Adapter code
  * may call any output method from any thread with no locking.
  * <p>
- * <b>The reuse boundary (decision D2).</b> The protocol-agnostic v1 SDK subset is reused as-is and never
+ * <b>The reuse boundary.</b> The protocol-agnostic v1 SDK subset is reused as-is and never
  * duplicated here: values are {@link com.hivemq.adapter.sdk.api.data.DataPoint} (built with
  * {@link com.hivemq.adapter.sdk.api.factories.DataPointFactory}), value, configuration, and node-definition
  * shapes are {@link com.hivemq.adapter.sdk.api.schema.Schema}, browse node kinds are

--- a/src/main/java/com/hivemq/adapter/sdk/api/v2/services/ProtocolAdapterService.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/v2/services/ProtocolAdapterService.java
@@ -30,8 +30,11 @@ public interface ProtocolAdapterService {
     @NotNull DataPointFactory dataPointFactory();
 
     /**
-     * @return the dispatcher a message-driven adapter attaches its mailbox to (single-threaded behavior). An
-     *         author who needs a different threading model supplies a different {@link MessageDispatcher}.
+     * @return the dispatcher a message-driven adapter attaches its mailbox to (single-threaded behavior). Every
+     *         binding opened through this dispatcher is owned by the framework and released when the adapter instance
+     *         is discarded (removal, full recreate, or subsystem shutdown), so an adapter need not be
+     *         {@link AutoCloseable} to have its dispatch thread cleaned up. An author who needs a different threading
+     *         model supplies a different {@link MessageDispatcher}.
      */
     @NotNull MessageDispatcher dispatcher();
 }

--- a/src/main/java/com/hivemq/adapter/sdk/api/v2/template/AbstractProtocolAdapter.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/v2/template/AbstractProtocolAdapter.java
@@ -20,11 +20,13 @@ import com.hivemq.adapter.sdk.api.factories.DataPointFactory;
 import com.hivemq.adapter.sdk.api.v2.ProtocolAdapter;
 import com.hivemq.adapter.sdk.api.v2.messaging.DefaultMailbox;
 import com.hivemq.adapter.sdk.api.v2.messaging.Mailbox;
+import com.hivemq.adapter.sdk.api.v2.messaging.MessageDispatcherHandle;
 import com.hivemq.adapter.sdk.api.v2.messaging.MessageHandler;
 import com.hivemq.adapter.sdk.api.v2.messaging.command.ProtocolAdapterBatchProcessCommand;
 import com.hivemq.adapter.sdk.api.v2.messaging.command.ProtocolAdapterCommand;
 import com.hivemq.adapter.sdk.api.v2.messaging.command.ProtocolAdapterConnectionCommand;
 import com.hivemq.adapter.sdk.api.v2.model.BrowseFilter;
+import com.hivemq.adapter.sdk.api.v2.model.ErrorScope;
 import com.hivemq.adapter.sdk.api.v2.model.ProtocolAdapterInput;
 import com.hivemq.adapter.sdk.api.v2.model.ProtocolAdapterOutput;
 import com.hivemq.adapter.sdk.api.v2.model.VerifyOutcome;
@@ -54,8 +56,16 @@ import org.jetbrains.annotations.NotNull;
  * {@link ProtocolAdapter} directly, or supply a different
  * {@link com.hivemq.adapter.sdk.api.v2.messaging.MessageDispatcher} via
  * {@link com.hivemq.adapter.sdk.api.v2.services.ProtocolAdapterService#dispatcher()}.
+ * <p>
+ * <b>Teardown.</b> The adapter owns one long-lived dispatch thread, attached at construction. It is
+ * {@link AutoCloseable} so the framework can release that thread when the adapter instance is discarded — on
+ * removal, a full recreate, or subsystem shutdown. {@link #close()} is the framework's teardown seam, distinct from
+ * {@link #stop()}: a stopped adapter may be started again, so the dispatch thread is detached only by {@code close()},
+ * never by a plain {@code stop()}. An author releases protocol-library resources in {@link #doStop()} and never calls
+ * {@code close()}.
  */
-public abstract class AbstractProtocolAdapter implements ProtocolAdapter, MessageHandler<ProtocolAdapterCommand> {
+public abstract class AbstractProtocolAdapter
+        implements ProtocolAdapter, MessageHandler<ProtocolAdapterCommand>, AutoCloseable {
 
     /**
      * The adapter's output to the framework — its state-and-event tell-façade. Thread-safe: callable from any
@@ -70,10 +80,12 @@ public abstract class AbstractProtocolAdapter implements ProtocolAdapter, Messag
 
     private final @NotNull String adapterId;
     private final @NotNull Mailbox<ProtocolAdapterCommand> mailbox;
+    private final @NotNull MessageDispatcherHandle dispatcherHandle;
 
     /**
      * Creates the adapter's mailbox and attaches it, with the adapter as the message handler, to the
-     * framework-supplied dispatcher. Construction is synchronous and cheap: no I/O, no connection.
+     * framework-supplied dispatcher, retaining the binding handle so the framework can detach the dispatch thread on
+     * teardown. Construction is synchronous and cheap: no I/O, no connection.
      *
      * @param input         everything this adapter instance is constructed from.
      * @param output the framework's state-and-event reporter.
@@ -84,12 +96,23 @@ public abstract class AbstractProtocolAdapter implements ProtocolAdapter, Messag
         this.dataPointFactory = input.services().dataPointFactory();
         this.adapterId = input.adapterId();
         this.mailbox = new DefaultMailbox<>();
-        input.services().dispatcher().attach(mailbox, this);
+        this.dispatcherHandle = input.services().dispatcher().attach(mailbox, this);
     }
 
     @Override
     public final @NotNull String adapterId() {
         return adapterId;
+    }
+
+    /**
+     * Detach this adapter's dispatch thread from the framework dispatcher. The framework calls this once, only when
+     * the adapter instance is discarded (removal, full recreate, or subsystem shutdown) — never on a plain
+     * {@link #stop()}, since a stopped adapter may be started again. Idempotent; an in-flight {@code do*} completes
+     * first.
+     */
+    @Override
+    public final void close() {
+        dispatcherHandle.close();
     }
 
     // ── ProtocolAdapter: every command is one thread-safe tell ──────────────────────────────────
@@ -148,6 +171,14 @@ public abstract class AbstractProtocolAdapter implements ProtocolAdapter, Messag
 
     @Override
     public final void receive(final @NotNull ProtocolAdapterCommand command) {
+        try {
+            dispatch(command);
+        } catch (final RuntimeException failure) {
+            reportCommandFailure(command, failure);
+        }
+    }
+
+    private void dispatch(final @NotNull ProtocolAdapterCommand command) {
         switch (command) {
             case ProtocolAdapterConnectionCommand.Start start -> doStart();
             case ProtocolAdapterConnectionCommand.Stop stop -> doStop();
@@ -162,6 +193,27 @@ public abstract class AbstractProtocolAdapter implements ProtocolAdapter, Messag
             case ProtocolAdapterBatchProcessCommand.WriteBatch writeBatch -> doWriteBatch(writeBatch.entries());
             case ProtocolAdapterBatchProcessCommand.Browse browse -> doBrowse(browse.filter());
         }
+    }
+
+    /**
+     * A {@code do*} method threw an unchecked exception: surface it to the framework instead of letting it escape the
+     * dispatch thread (where it would terminate the actor). A failed {@code doStop()} still acknowledges
+     * {@link ProtocolAdapterOutput#stopped()} — the framework has decided to stop, and a partial teardown failure does
+     * not change that — while every other command reports an {@link ErrorScope#ADAPTER} error, which the framework
+     * turns into the wrapper's {@code ERROR} state with a clear reason.
+     *
+     * @param command the command whose {@code do*} method failed.
+     * @param failure the unchecked exception it threw.
+     */
+    private void reportCommandFailure(
+            final @NotNull ProtocolAdapterCommand command, final @NotNull RuntimeException failure) {
+        if (command instanceof ProtocolAdapterConnectionCommand.Stop) {
+            output.stopped();
+            return;
+        }
+        output.error(
+                ErrorScope.ADAPTER,
+                "adapter [" + adapterId + "] command " + command.getClass().getSimpleName() + " failed: " + failure);
     }
 
     // ── Default batch fallbacks: loop the single-node methods; a native override wins ────────────

--- a/src/test/java/com/hivemq/adapter/sdk/api/v2/ReuseBoundaryTest.java
+++ b/src/test/java/com/hivemq/adapter/sdk/api/v2/ReuseBoundaryTest.java
@@ -40,7 +40,7 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * The reuse boundary (decision D2) and naming rule N2: {@code api.v2} references the reused v1 types
+ * The SDK reuse boundary and its no-abbreviations naming rule: {@code api.v2} references the reused v1 types
  * — {@link DataPoint}, {@link Schema}, {@link NodeType}, the category and search-tag enums — and never shadows
  * them; the package name carries the version, so no type takes a {@code 2} suffix and no identifier contains a
  * known abbreviation.

--- a/src/test/java/com/hivemq/adapter/sdk/api/v2/messaging/DefaultMailboxMpscTest.java
+++ b/src/test/java/com/hivemq/adapter/sdk/api/v2/messaging/DefaultMailboxMpscTest.java
@@ -35,7 +35,7 @@ import static org.awaitility.Awaitility.await;
 
 /**
  * The multi-producer / single-consumer contract of {@link DefaultMailbox} on REAL threads — Awaitility only,
- * never {@code Thread.sleep}. (Scenario S23 at the SDK level.)
+ * never {@code Thread.sleep}.
  */
 class DefaultMailboxMpscTest {
 

--- a/src/test/java/com/hivemq/adapter/sdk/api/v2/template/AbstractProtocolAdapterTeardownAndFaultTest.java
+++ b/src/test/java/com/hivemq/adapter/sdk/api/v2/template/AbstractProtocolAdapterTeardownAndFaultTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2023-present HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hivemq.adapter.sdk.api.v2.template;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hivemq.adapter.sdk.api.data.DataPoint;
+import com.hivemq.adapter.sdk.api.v2.model.ProtocolAdapterInput;
+import com.hivemq.adapter.sdk.api.v2.model.ProtocolAdapterOutput;
+import com.hivemq.adapter.sdk.api.v2.node.Node;
+import java.util.ArrayList;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The template's two robustness guarantees. <b>Teardown:</b> the adapter attaches its own dispatch thread at
+ * construction and owns the binding, so {@link AbstractProtocolAdapter#close()} detaches it — the framework's seam to
+ * release the thread when the adapter instance is discarded, distinct from a plain {@code stop()}. <b>Fault
+ * tolerance:</b> a {@code do*} method that throws an unchecked exception never escapes the dispatch loop — a failed
+ * {@code doStop()} still acknowledges {@code stopped()}, every other failure is surfaced as an {@code ADAPTER} error,
+ * and the adapter keeps processing later commands.
+ */
+class AbstractProtocolAdapterTeardownAndFaultTest {
+
+    @Test
+    void close_detachesTheAdapterFromTheDispatcher() {
+        final ManualDispatcher dispatcher = new ManualDispatcher();
+        final FaultyAdapter adapter =
+                new FaultyAdapter(TestProtocolAdapterInput.create("a", dispatcher), new RecordingProtocolAdapterOutput());
+
+        adapter.close();
+        adapter.start();
+        dispatcher.drainAll();
+
+        // The binding is gone, so the queued command is never delivered: the dispatch thread has been released.
+        assertThat(adapter.executed).isEmpty();
+    }
+
+    @Test
+    void throwingDoConnect_reportsAdapterError_andTheAdapterStillProcessesLaterCommands() {
+        final ManualDispatcher dispatcher = new ManualDispatcher();
+        final RecordingProtocolAdapterOutput output = new RecordingProtocolAdapterOutput();
+        final FaultyAdapter adapter =
+                new FaultyAdapter(TestProtocolAdapterInput.create("a", dispatcher), output);
+        adapter.failConnect = true;
+
+        adapter.connect();
+        adapter.start();
+        dispatcher.drainAll();
+
+        // The thrown connect is surfaced as an ADAPTER error, not allowed to escape the dispatch loop, and the next
+        // command (start) is still processed — the adapter did not die.
+        assertThat(output.invocations()).anyMatch(invocation -> invocation.startsWith("error:ADAPTER"));
+        assertThat(adapter.executed).containsExactly("doConnect", "doStart");
+    }
+
+    @Test
+    void throwingDoStop_stillAcknowledgesStopped() {
+        final ManualDispatcher dispatcher = new ManualDispatcher();
+        final RecordingProtocolAdapterOutput output = new RecordingProtocolAdapterOutput();
+        final FaultyAdapter adapter =
+                new FaultyAdapter(TestProtocolAdapterInput.create("a", dispatcher), output);
+        adapter.failStop = true;
+
+        adapter.stop();
+        dispatcher.drainAll();
+
+        // stop() must always acknowledge stopped(), even when the teardown threw.
+        assertThat(output.invocations()).contains("stopped");
+    }
+
+    private static final class FaultyAdapter extends AbstractProtocolAdapter {
+
+        private final @NotNull List<String> executed = new ArrayList<>();
+        private boolean failConnect;
+        private boolean failStop;
+
+        FaultyAdapter(final @NotNull ProtocolAdapterInput input, final @NotNull ProtocolAdapterOutput output) {
+            super(input, output);
+        }
+
+        @Override
+        protected void doStart() {
+            executed.add("doStart");
+            output.started();
+        }
+
+        @Override
+        protected void doStop() {
+            executed.add("doStop");
+            if (failStop) {
+                throw new IllegalStateException("teardown blew up");
+            }
+            output.stopped();
+        }
+
+        @Override
+        protected void doConnect() {
+            executed.add("doConnect");
+            if (failConnect) {
+                throw new IllegalStateException("connect blew up");
+            }
+            output.connected();
+        }
+
+        @Override
+        protected void doDisconnect() {
+            executed.add("doDisconnect");
+            output.disconnected();
+        }
+
+        @Override
+        protected void doPoll(final @NotNull Node node) {
+            executed.add("doPoll");
+        }
+
+        @Override
+        protected void doAddSubscription(final @NotNull Node node) {
+        }
+
+        @Override
+        protected void doWrite(final @NotNull Node node, final @NotNull DataPoint value) {
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Round-1 code-review remediation for the Nevsky v2 SDK — finding **GUIDELINE-001** only.

Rule N4 requires that the open-sourced SDK source not cite internal design-document labels. This removes the
"decision D2" reuse-boundary references from the `api.v2` Javadoc:

- `api/v2/package-info.java`
- `api/v2/node/package-info.java`
- `ProtocolAdapterInformation.java`

Each now reads "reuse boundary" with no internal label. **Javadoc-only — no API or behavioral change.**

## Verification
`:hivemq-edge-adapter-sdk:check` (Spotless + ErrorProne + NullAway + SDK tests) green.

Companion PRs: `hivemq-edge` (the BUG-001..004 fixes), `hivemq-edge-test` (wired end-to-end tests).
