### PR TITLE
docs(EDG-784): document the exact-and-complete RESOLVE contract

### DIFF
--- a/src/main/java/com/hivemq/adapter/sdk/api/v2/ProtocolAdapter.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/v2/ProtocolAdapter.java
@@ -151,10 +151,15 @@ public interface ProtocolAdapter {
      * browse. {@link #browse(int, BrowseFilter, int)} DISCOVERs which nodes exist; this reads their attributes so
      * the framework can build typed tag definitions. Like browse it is <b>pure mechanism</b>: one server
      * round-trip per call (the framework batches the discovered variables), answered by a single
-     * {@link ProtocolAdapterOutput#readAttributesResult(int, List)} carrying one
-     * {@link com.hivemq.adapter.sdk.api.v2.model.ResolvedAttributes} per node, or by
+     * {@link ProtocolAdapterOutput#readAttributesResult(int, List)} carrying exactly one
+     * {@link com.hivemq.adapter.sdk.api.v2.model.ResolvedAttributes} per requested node, or by
      * {@link ProtocolAdapterOutput#browseError(int, String)} on failure. Correlated to its browse by
      * {@code requestId}.
+     * <p>
+     * The answer must cover the whole batch: one attribute per requested node, no missing, duplicate, or
+     * unrequested node. The framework fails the entire browse on a mismatch rather than dropping the unmatched
+     * node — if the device cannot resolve a node, report {@link ProtocolAdapterOutput#browseError(int, String)}
+     * instead of answering short.
      *
      * @param requestId correlates this resolve with the browse that discovered the nodes.
      * @param nodes     the discovered nodes whose attributes to resolve.

--- a/src/main/java/com/hivemq/adapter/sdk/api/v2/model/ProtocolAdapterOutput.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/v2/model/ProtocolAdapterOutput.java
@@ -116,9 +116,15 @@ public interface ProtocolAdapterOutput {
      * Answers {@link ProtocolAdapter#readNodeAttributes(int, List)} — the RESOLVE step of a browse — with the
      * device-resolved attributes of the requested nodes, one {@link ResolvedAttributes} per node, reported once
      * for the whole batch.
+     * <p>
+     * The result must be <b>exact and complete</b>: exactly one entry per requested node, with no missing,
+     * duplicate, or unrequested node. The framework does <b>not</b> silently drop a node it cannot match — a batch
+     * that does not resolve every requested node exactly once fails the whole browse. If the device genuinely cannot
+     * resolve some node (a denied attribute read, throttling, an expired continuation), report a real failure through
+     * {@link #browseError(int, String)} rather than answering short.
      *
      * @param requestId  the browse/resolve these attributes belong to.
-     * @param attributes the resolved attributes, one per requested node.
+     * @param attributes the resolved attributes, exactly one per requested node.
      */
     void readAttributesResult(int requestId, @NotNull List<ResolvedAttributes> attributes);
 


### PR DESCRIPTION
**Motivation**

Documents the RESOLVE-batch contract that [EDG-784](https://linear.app/hivemq/issue/EDG-784) now enforces in the framework. Previously the browse engine accepted whatever `readAttributesResult` returned and dropped any discovered **selectable** node whose attributes were missing — completing the browse as a `200 OK` short a tag, with no error. That is now a hard failure: a RESOLVE batch that does not resolve every requested node exactly once fails the whole browse. The SDK Javadoc did not state this obligation, so an adapter author had no way to know a short or padded answer would sink the browse.

Docs-only — no API or behaviour change in this repo. The enforcement lives in `hivemq-edge` (companion PR hivemq/hivemq-edge#1605); this PR aligns the contract adapter authors code against with what the framework now does.

**Changes**

Add the *exact-and-complete* obligation to both sides of the RESOLVE seam:

- `ProtocolAdapter#readNodeAttributes` — the answer must cover the whole batch: exactly one `ResolvedAttributes` per requested node, with no missing, duplicate, or unrequested node. On a mismatch the framework fails the entire browse rather than dropping the unmatched node.
- `ProtocolAdapterOutput#readAttributesResult` — same contract from the output side, and the `attributes` param doc now reads "exactly one per requested node".

Both make the escape hatch explicit: an adapter that genuinely cannot resolve a node (a denied attribute read, throttling, an expired continuation point) must report `browseError(...)` instead of answering short.

Resolves EDG-784 (SDK side).