### PR TITLE
EDG-812: Nevsky v2 — poll-completion boundary in the SDK v2 output contract

### DIFF
--- a/src/main/java/com/hivemq/adapter/sdk/api/v2/model/ProtocolAdapterOutput.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/v2/model/ProtocolAdapterOutput.java
@@ -74,7 +74,14 @@ public interface ProtocolAdapterOutput {
     void verifyResult(@NotNull Node node, @NotNull VerifyOutcome outcome);
 
     /**
-     * Reports one value — a poll response or a subscription push; the {@link Node} is the correlation key.
+     * Reports one value; the {@link Node} is the correlation key. For a <b>poll</b> this value also <b>completes</b>
+     * the poll — the common single-value case — so the framework resumes the node's poll cadence and no
+     * {@link #pollComplete(Node)} is needed. For a <b>subscription</b> it is a pushed value; the completion is
+     * meaningless there (a subscription never completes) and is ignored.
+     * <p>
+     * A poll that produces more than one value uses {@link #dataPoints(Node, List)} for the non-final values and
+     * terminates with {@link #pollComplete(Node)} (or this method, or a {@link #nodeError(Node, String, boolean)});
+     * see the class contract.
      *
      * @param node  the node the value belongs to.
      * @param value the reused v1 value; tag name and adapter identifier are stamped by the framework.
@@ -82,14 +89,24 @@ public interface ProtocolAdapterOutput {
     void dataPoint(@NotNull Node node, @NotNull DataPoint value);
 
     /**
-     * Reports that the poll for this node has produced all its values — possibly zero — so the framework resumes the
-     * node's poll cadence. A poll may report any number of values with {@link #dataPoint(Node, DataPoint)} before its
-     * completion; values never end a poll, only this signal (or a {@link #nodeError(Node, String, boolean)}) does.
+     * Reports zero or more values for this node that do <b>not</b> complete its poll. Call it once, or repeatedly to
+     * stream a large result set page by page without materializing it whole, and end the poll with an explicit
+     * {@link #pollComplete(Node)} (or a {@link #nodeError(Node, String, boolean)} on a mid-stream failure). Each
+     * value is stamped and published in order; an empty list is a no-op that leaves the poll open.
      * <p>
-     * A synchronous adapter built on the template never calls this — the template completes each poll automatically
-     * after {@code doPoll} returns. An adapter whose poll finishes asynchronously (the value arrives on a client
-     * thread after {@code doPoll} returned) opts out of the automatic completion and calls this from its completion
-     * callback instead.
+     * For a <b>subscription</b> this simply pushes each value; there is no poll to keep open.
+     *
+     * @param node   the node the values belong to.
+     * @param values the reused v1 values, in order; tag name and adapter identifier are stamped by the framework.
+     */
+    void dataPoints(@NotNull Node node, @NotNull List<DataPoint> values);
+
+    /**
+     * Completes the poll for this node with no further value — the empty-result or deduplicated no-op case, or the
+     * terminator after one or more {@link #dataPoints(Node, List)} calls — so the framework resumes the node's poll
+     * cadence. A single-value poll does not need this: {@link #dataPoint(Node, DataPoint)} already completes it. The
+     * adapter always emits its own terminator (a completing {@code dataPoint}, this call, or a {@code nodeError});
+     * the template never completes a poll on the adapter's behalf.
      *
      * @param node the node whose poll is complete.
      */

--- a/src/main/java/com/hivemq/adapter/sdk/api/v2/model/ProtocolAdapterOutput.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/v2/model/ProtocolAdapterOutput.java
@@ -82,6 +82,20 @@ public interface ProtocolAdapterOutput {
     void dataPoint(@NotNull Node node, @NotNull DataPoint value);
 
     /**
+     * Reports that the poll for this node has produced all its values — possibly zero — so the framework resumes the
+     * node's poll cadence. A poll may report any number of values with {@link #dataPoint(Node, DataPoint)} before its
+     * completion; values never end a poll, only this signal (or a {@link #nodeError(Node, String, boolean)}) does.
+     * <p>
+     * A synchronous adapter built on the template never calls this — the template completes each poll automatically
+     * after {@code doPoll} returns. An adapter whose poll finishes asynchronously (the value arrives on a client
+     * thread after {@code doPoll} returned) opts out of the automatic completion and calls this from its completion
+     * callback instead.
+     *
+     * @param node the node whose poll is complete.
+     */
+    void pollComplete(@NotNull Node node);
+
+    /**
      * Reports a per-node failure (failed poll, failed or lost subscription).
      *
      * @param node        the node the failure belongs to.

--- a/src/main/java/com/hivemq/adapter/sdk/api/v2/template/AbstractProtocolAdapter.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/v2/template/AbstractProtocolAdapter.java
@@ -253,12 +253,39 @@ public abstract class AbstractProtocolAdapter
     }
 
     /**
-     * Default: one {@link #doPoll(Node)} per node. Override for a native batch read.
+     * Default: one {@link #doPoll(Node)} per node. On the synchronous path (see
+     * {@link #pollCompletesSynchronously()}) every node's poll is completed automatically with
+     * {@link ProtocolAdapterOutput#pollComplete(Node)} after its {@code doPoll} returns — even when {@code doPoll}
+     * throws — so a poll can never leave its node's cadence hanging. Override for a native batch read; a native
+     * override owns the completion of every node it polls.
      *
      * @param nodes the nodes to poll.
      */
     protected void doPollBatch(final @NotNull List<Node> nodes) {
-        nodes.forEach(this::doPoll);
+        if (pollCompletesSynchronously()) {
+            for (final Node node : nodes) {
+                try {
+                    doPoll(node);
+                } finally {
+                    output.pollComplete(node);
+                }
+            }
+        } else {
+            nodes.forEach(this::doPoll);
+        }
+    }
+
+    /**
+     * Whether a poll has produced all its values when {@link #doPoll(Node)} returns. Defaults to {@code true} — the
+     * template then completes each poll automatically. An adapter whose {@code doPoll} returns before its values
+     * arrive (an asynchronous client reporting on its own threads) overrides this to {@code false} and calls
+     * {@link ProtocolAdapterOutput#pollComplete(Node)} from its completion callback instead, on every completion
+     * path — a poll that never completes leaves its node waiting until the adapter disconnects.
+     *
+     * @return {@code true} if {@code doPoll} reports every value before returning.
+     */
+    protected boolean pollCompletesSynchronously() {
+        return true;
     }
 
     /**
@@ -375,9 +402,11 @@ public abstract class AbstractProtocolAdapter
     protected abstract void doDisconnect();
 
     /**
-     * Read the node's current value and report it with
-     * {@link ProtocolAdapterOutput#dataPoint(Node, DataPoint)} — build the value with
-     * {@link #dataPointFactory}; the framework stamps the tag name and adapter identifier.
+     * Read the node's current values — any number, possibly zero — and report each with
+     * {@link ProtocolAdapterOutput#dataPoint(Node, DataPoint)} — build the values with
+     * {@link #dataPointFactory}; the framework stamps the tag name and adapter identifier. On the synchronous path
+     * the template completes the poll when this returns; see {@link #pollCompletesSynchronously()} for adapters
+     * whose values arrive after this returns.
      *
      * @param node the node to poll.
      */

--- a/src/main/java/com/hivemq/adapter/sdk/api/v2/template/AbstractProtocolAdapter.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/v2/template/AbstractProtocolAdapter.java
@@ -253,39 +253,16 @@ public abstract class AbstractProtocolAdapter
     }
 
     /**
-     * Default: one {@link #doPoll(Node)} per node. On the synchronous path (see
-     * {@link #pollCompletesSynchronously()}) every node's poll is completed automatically with
-     * {@link ProtocolAdapterOutput#pollComplete(Node)} after its {@code doPoll} returns — even when {@code doPoll}
-     * throws — so a poll can never leave its node's cadence hanging. Override for a native batch read; a native
-     * override owns the completion of every node it polls.
+     * Default: one {@link #doPoll(Node)} per node — the template never completes a poll on the adapter's behalf.
+     * Each {@code doPoll} owns its own terminator (a completing {@link ProtocolAdapterOutput#dataPoint(Node, DataPoint)},
+     * a {@link ProtocolAdapterOutput#pollComplete(Node)}, or a {@link ProtocolAdapterOutput#nodeError(Node, String, boolean)}),
+     * so a poll that reports nothing at all leaves its node's cadence waiting until the adapter disconnects. Override
+     * for a native batch read.
      *
      * @param nodes the nodes to poll.
      */
     protected void doPollBatch(final @NotNull List<Node> nodes) {
-        if (pollCompletesSynchronously()) {
-            for (final Node node : nodes) {
-                try {
-                    doPoll(node);
-                } finally {
-                    output.pollComplete(node);
-                }
-            }
-        } else {
-            nodes.forEach(this::doPoll);
-        }
-    }
-
-    /**
-     * Whether a poll has produced all its values when {@link #doPoll(Node)} returns. Defaults to {@code true} — the
-     * template then completes each poll automatically. An adapter whose {@code doPoll} returns before its values
-     * arrive (an asynchronous client reporting on its own threads) overrides this to {@code false} and calls
-     * {@link ProtocolAdapterOutput#pollComplete(Node)} from its completion callback instead, on every completion
-     * path — a poll that never completes leaves its node waiting until the adapter disconnects.
-     *
-     * @return {@code true} if {@code doPoll} reports every value before returning.
-     */
-    protected boolean pollCompletesSynchronously() {
-        return true;
+        nodes.forEach(this::doPoll);
     }
 
     /**
@@ -402,11 +379,18 @@ public abstract class AbstractProtocolAdapter
     protected abstract void doDisconnect();
 
     /**
-     * Read the node's current values — any number, possibly zero — and report each with
-     * {@link ProtocolAdapterOutput#dataPoint(Node, DataPoint)} — build the values with
-     * {@link #dataPointFactory}; the framework stamps the tag name and adapter identifier. On the synchronous path
-     * the template completes the poll when this returns; see {@link #pollCompletesSynchronously()} for adapters
-     * whose values arrive after this returns.
+     * Read the node's current values — any number, possibly zero — and report them, building the values with
+     * {@link #dataPointFactory} (the framework stamps the tag name and adapter identifier). Every path must end the
+     * poll with its own terminator:
+     * <ul>
+     * <li>one value → {@link ProtocolAdapterOutput#dataPoint(Node, DataPoint)} (it completes the poll);</li>
+     * <li>many values → {@link ProtocolAdapterOutput#dataPoints(Node, List)} (repeatable) then
+     *     {@link ProtocolAdapterOutput#pollComplete(Node)};</li>
+     * <li>no value → {@link ProtocolAdapterOutput#pollComplete(Node)};</li>
+     * <li>a failure → {@link ProtocolAdapterOutput#nodeError(Node, String, boolean)}.</li>
+     * </ul>
+     * An adapter whose values arrive after this returns (an asynchronous client reporting on its own threads) issues
+     * the same terminating calls from its completion callback. The template does not complete the poll for it.
      *
      * @param node the node to poll.
      */

--- a/src/test/java/com/hivemq/adapter/sdk/api/v2/template/DefaultBatchFallbackTest.java
+++ b/src/test/java/com/hivemq/adapter/sdk/api/v2/template/DefaultBatchFallbackTest.java
@@ -88,6 +88,32 @@ class DefaultBatchFallbackTest {
         }
     }
 
+    private static final class AsynchronouslyCompletingAdapter extends SingleNodeRecordingAdapter {
+
+        AsynchronouslyCompletingAdapter(
+                final @NotNull ProtocolAdapterInput input, final @NotNull ProtocolAdapterOutput reporter) {
+            super(input, reporter);
+        }
+
+        @Override
+        protected boolean pollCompletesSynchronously() {
+            return false;
+        }
+    }
+
+    private static final class ThrowingPollAdapter extends SingleNodeRecordingAdapter {
+
+        ThrowingPollAdapter(
+                final @NotNull ProtocolAdapterInput input, final @NotNull ProtocolAdapterOutput reporter) {
+            super(input, reporter);
+        }
+
+        @Override
+        protected void doPoll(final @NotNull Node node) {
+            throw new IllegalStateException("the device fell over");
+        }
+    }
+
     @Test
     void pollBatch_fallsBackToOneDoPollPerNode_inBatchOrder() {
         final ManualDispatcher dispatcher = new ManualDispatcher();
@@ -98,6 +124,48 @@ class DefaultBatchFallbackTest {
 
         dispatcher.drainAll();
         assertThat(adapter.executed).containsExactly("doPoll:node-a", "doPoll:node-b");
+    }
+
+    @Test
+    void pollBatch_completesEveryNodeAutomaticallyOnTheSynchronousPath() {
+        final ManualDispatcher dispatcher = new ManualDispatcher();
+        final RecordingProtocolAdapterOutput output = new RecordingProtocolAdapterOutput();
+        final SingleNodeRecordingAdapter adapter = new SingleNodeRecordingAdapter(
+                TestProtocolAdapterInput.create("adapter-1", dispatcher), output);
+
+        adapter.pollBatch(List.of(new TestNode("node-a"), new TestNode("node-b")));
+
+        dispatcher.drainAll();
+        assertThat(output.invocations()).containsExactly("pollComplete:node-a", "pollComplete:node-b");
+    }
+
+    @Test
+    void pollBatch_completesTheNodeEvenWhenItsPollThrows() {
+        final ManualDispatcher dispatcher = new ManualDispatcher();
+        final RecordingProtocolAdapterOutput output = new RecordingProtocolAdapterOutput();
+        final ThrowingPollAdapter adapter = new ThrowingPollAdapter(
+                TestProtocolAdapterInput.create("adapter-1", dispatcher), output);
+
+        adapter.pollBatch(List.of(new TestNode("node-a")));
+
+        dispatcher.drainAll();
+        assertThat(output.invocations()).hasSize(2);
+        assertThat(output.invocations().get(0)).isEqualTo("pollComplete:node-a");
+        assertThat(output.invocations().get(1)).startsWith("error:ADAPTER");
+    }
+
+    @Test
+    void pollBatch_doesNotAutoCompleteWhenTheAdapterCompletesAsynchronously() {
+        final ManualDispatcher dispatcher = new ManualDispatcher();
+        final RecordingProtocolAdapterOutput output = new RecordingProtocolAdapterOutput();
+        final AsynchronouslyCompletingAdapter adapter = new AsynchronouslyCompletingAdapter(
+                TestProtocolAdapterInput.create("adapter-1", dispatcher), output);
+
+        adapter.pollBatch(List.of(new TestNode("node-a"), new TestNode("node-b")));
+
+        dispatcher.drainAll();
+        assertThat(adapter.executed).containsExactly("doPoll:node-a", "doPoll:node-b");
+        assertThat(output.invocations()).isEmpty();
     }
 
     @Test

--- a/src/test/java/com/hivemq/adapter/sdk/api/v2/template/DefaultBatchFallbackTest.java
+++ b/src/test/java/com/hivemq/adapter/sdk/api/v2/template/DefaultBatchFallbackTest.java
@@ -88,19 +88,6 @@ class DefaultBatchFallbackTest {
         }
     }
 
-    private static final class AsynchronouslyCompletingAdapter extends SingleNodeRecordingAdapter {
-
-        AsynchronouslyCompletingAdapter(
-                final @NotNull ProtocolAdapterInput input, final @NotNull ProtocolAdapterOutput reporter) {
-            super(input, reporter);
-        }
-
-        @Override
-        protected boolean pollCompletesSynchronously() {
-            return false;
-        }
-    }
-
     private static final class ThrowingPollAdapter extends SingleNodeRecordingAdapter {
 
         ThrowingPollAdapter(
@@ -127,7 +114,7 @@ class DefaultBatchFallbackTest {
     }
 
     @Test
-    void pollBatch_completesEveryNodeAutomaticallyOnTheSynchronousPath() {
+    void pollBatch_doesNotCompleteOnTheAdaptersBehalf() {
         final ManualDispatcher dispatcher = new ManualDispatcher();
         final RecordingProtocolAdapterOutput output = new RecordingProtocolAdapterOutput();
         final SingleNodeRecordingAdapter adapter = new SingleNodeRecordingAdapter(
@@ -136,11 +123,14 @@ class DefaultBatchFallbackTest {
         adapter.pollBatch(List.of(new TestNode("node-a"), new TestNode("node-b")));
 
         dispatcher.drainAll();
-        assertThat(output.invocations()).containsExactly("pollComplete:node-a", "pollComplete:node-b");
+        // The template loops doPoll; each poll owns its own terminator, so a doPoll that reports nothing leaves the
+        // output empty — the template never completes a poll on the adapter's behalf.
+        assertThat(adapter.executed).containsExactly("doPoll:node-a", "doPoll:node-b");
+        assertThat(output.invocations()).isEmpty();
     }
 
     @Test
-    void pollBatch_completesTheNodeEvenWhenItsPollThrows() {
+    void pollBatch_reportsAnAdapterErrorWhenAPollThrows() {
         final ManualDispatcher dispatcher = new ManualDispatcher();
         final RecordingProtocolAdapterOutput output = new RecordingProtocolAdapterOutput();
         final ThrowingPollAdapter adapter = new ThrowingPollAdapter(
@@ -149,23 +139,9 @@ class DefaultBatchFallbackTest {
         adapter.pollBatch(List.of(new TestNode("node-a")));
 
         dispatcher.drainAll();
-        assertThat(output.invocations()).hasSize(2);
-        assertThat(output.invocations().get(0)).isEqualTo("pollComplete:node-a");
-        assertThat(output.invocations().get(1)).startsWith("error:ADAPTER");
-    }
-
-    @Test
-    void pollBatch_doesNotAutoCompleteWhenTheAdapterCompletesAsynchronously() {
-        final ManualDispatcher dispatcher = new ManualDispatcher();
-        final RecordingProtocolAdapterOutput output = new RecordingProtocolAdapterOutput();
-        final AsynchronouslyCompletingAdapter adapter = new AsynchronouslyCompletingAdapter(
-                TestProtocolAdapterInput.create("adapter-1", dispatcher), output);
-
-        adapter.pollBatch(List.of(new TestNode("node-a"), new TestNode("node-b")));
-
-        dispatcher.drainAll();
-        assertThat(adapter.executed).containsExactly("doPoll:node-a", "doPoll:node-b");
-        assertThat(output.invocations()).isEmpty();
+        // An uncaught doPoll exception surfaces as an ADAPTER error; there is no template-issued completion.
+        assertThat(output.invocations()).hasSize(1);
+        assertThat(output.invocations().get(0)).startsWith("error:ADAPTER");
     }
 
     @Test

--- a/src/test/java/com/hivemq/adapter/sdk/api/v2/template/RecordingProtocolAdapterOutput.java
+++ b/src/test/java/com/hivemq/adapter/sdk/api/v2/template/RecordingProtocolAdapterOutput.java
@@ -78,6 +78,11 @@ final class RecordingProtocolAdapterOutput implements ProtocolAdapterOutput {
     }
 
     @Override
+    public void pollComplete(final @NotNull Node node) {
+        invocations.add("pollComplete:" + node.nodeId());
+    }
+
+    @Override
     public void nodeError(final @NotNull Node node, final @NotNull String reason, final boolean spontaneous) {
         invocations.add("nodeError:" + node.nodeId() + ":" + reason + ":" + spontaneous);
     }

--- a/src/test/java/com/hivemq/adapter/sdk/api/v2/template/RecordingProtocolAdapterOutput.java
+++ b/src/test/java/com/hivemq/adapter/sdk/api/v2/template/RecordingProtocolAdapterOutput.java
@@ -78,6 +78,14 @@ final class RecordingProtocolAdapterOutput implements ProtocolAdapterOutput {
     }
 
     @Override
+    public void dataPoints(final @NotNull Node node, final @NotNull List<DataPoint> values) {
+        for (final DataPoint value : values) {
+            invocations.add("dataPoints:" + node.nodeId());
+            dataPoints.add(value);
+        }
+    }
+
+    @Override
     public void pollComplete(final @NotNull Node node) {
         invocations.add("pollComplete:" + node.nodeId());
     }

--- a/src/test/java/com/hivemq/adapter/sdk/api/v2/template/TestTemplateAdapterTest.java
+++ b/src/test/java/com/hivemq/adapter/sdk/api/v2/template/TestTemplateAdapterTest.java
@@ -67,12 +67,8 @@ class TestTemplateAdapterTest {
         adapter.pollBatch(List.of(new TestNode("temperature"), new TestNode("pressure")));
 
         dispatcher.drainAll();
-        assertThat(callbacks.invocations())
-                .containsExactly(
-                        "dataPoint:temperature",
-                        "pollComplete:temperature",
-                        "dataPoint:pressure",
-                        "pollComplete:pressure");
+        // A single dataPoint per node completes each poll itself — the template adds no pollComplete.
+        assertThat(callbacks.invocations()).containsExactly("dataPoint:temperature", "dataPoint:pressure");
         assertThat(callbacks.dataPoints()).hasSize(2);
 
         final DataPoint first = callbacks.dataPoints().get(0);

--- a/src/test/java/com/hivemq/adapter/sdk/api/v2/template/TestTemplateAdapterTest.java
+++ b/src/test/java/com/hivemq/adapter/sdk/api/v2/template/TestTemplateAdapterTest.java
@@ -67,7 +67,12 @@ class TestTemplateAdapterTest {
         adapter.pollBatch(List.of(new TestNode("temperature"), new TestNode("pressure")));
 
         dispatcher.drainAll();
-        assertThat(callbacks.invocations()).containsExactly("dataPoint:temperature", "dataPoint:pressure");
+        assertThat(callbacks.invocations())
+                .containsExactly(
+                        "dataPoint:temperature",
+                        "pollComplete:temperature",
+                        "dataPoint:pressure",
+                        "pollComplete:pressure");
         assertThat(callbacks.dataPoints()).hasSize(2);
 
         final DataPoint first = callbacks.dataPoints().get(0);


### PR DESCRIPTION
**Motivation**

Part of [EDG-812](https://linear.app/hivemq/issue/EDG-812) (Databases → SDK v2 port). The v2 polled-read aspect ended a poll on its first value, so a poll could never publish more than one value — but the Databases adapter's `spiltLinesInIndividualMessages` needs one message per result row. This PR adds the explicit poll-completion boundary to the SDK output contract, decoupling poll cadence from value arrival so a poll may report 0..N values.

Companion PRs on the same branch: hivemq-edge (framework routing + databases-v2 module), hivemq-edge-test (end-to-end suite), hivemq-edge-composite (distribution).

**Changes**

- `ProtocolAdapterOutput.pollComplete(Node)`: the signal that a poll has produced all its values (possibly zero); values never end a poll, only this signal or a per-node error does.
- `AbstractProtocolAdapter.doPollBatch` auto-completes every node's poll in a `finally` after `doPoll` returns — a synchronous adapter can never leave its node's cadence hanging, even when `doPoll` throws.
- `pollCompletesSynchronously()` opt-out hook for adapters whose values arrive on a client thread after `doPoll` returned; they complete from their own callback (the v2 HTTP adapter does this in the hivemq-edge PR).
- Tests: template auto-completion sequence, the throwing-poll path (completion still emitted, then the ADAPTER-scope error), and the asynchronous opt-out (no auto-completion).