### PR TITLE
docs: fix Contributing link text in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -15,7 +15,7 @@ Resources:
 
 * Web Site: {hivemq-website}
 * Community Forum: {hivemq-community-forum}
-* Contribution Guidelines: link:CONTRIBUTING.md[Contributing.adoc]
+* Contribution Guidelines: link:CONTRIBUTING.md[Contributing Guidelines]
 * License: The source files in this repository are made available under the link:LICENSE[Apache License Version 2.0].
 
 == Using the Adapter SDK


### PR DESCRIPTION
## What

Fixes the link text for the contribution guidelines in `README.adoc`. The link pointed to `CONTRIBUTING.md` but the display text incorrectly read `Contributing.adoc`.

## Why

Minor docs correction; also serves to exercise the repo's CI build.

## How to verify

Rendered README shows the contribution guidelines link labelled "Contributing Guidelines" pointing to CONTRIBUTING.md.