### PR TITLE
EDG-845: Separate northbound (read) and southbound (write) tag schemas

### DIFF
--- a/src/main/java/com/hivemq/adapter/sdk/api/schema/SchemaJsonRepresentation.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/schema/SchemaJsonRepresentation.java
@@ -48,23 +48,16 @@ public final class SchemaJsonRepresentation {
         return toJsonSchema(schema).toString();
     }
 
-    public ObjectNode toCompositeSchema(final @NotNull TagSchemaCreationOutput.DataPointSchema dps) {
-        final var builder = new SchemaBuilder().startObject();
-
-        builder.property("tagName").scalar(ScalarType.STRING).readable().writable(false);
-        builder.property("timestamp").scalar(ScalarType.LONG).readable().writable(false);
-        builder.property("value").required().schema(dps.valueSchema()).readable().writable();
-
-
-
-        if (dps.metadataSchema() != null) {
-            builder.property("metadata").schema(dps.metadataSchema()).readable().writable(false);
-        }
-        if (dps.context() != null) {
-            builder.property("context").schema(dps.context()).readable().writable(false);
-        }
-
-        final var result = toJsonSchema(builder.endObject().build());
+    /**
+     * Renders a schema as a standalone JSON Schema <em>document</em> — i.e. {@link #toJsonSchema} plus the
+     * {@code $schema} declaration that makes the result a self-contained document.
+     * <p>
+     * This class knows nothing about tag directions (read / write) or how a composite is assembled from a
+     * {@link TagSchemaCreationOutput.DataPointSchema}; it only converts between {@link Schema} and JSON Schema.
+     * Composition is the caller's concern.
+     */
+    public @NotNull ObjectNode toJsonSchemaDocument(final @NotNull Schema schema) {
+        final var result = toJsonSchema(schema);
         result.set("$schema", new TextNode(SCHEMA_URI));
         return result;
     }

--- a/src/main/java/com/hivemq/adapter/sdk/api/schema/SchemaJsonRepresentation.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/schema/SchemaJsonRepresentation.java
@@ -49,6 +49,33 @@ public final class SchemaJsonRepresentation {
     }
 
     /**
+     * Assembles the read view of a data point — the {@code tagName}/{@code timestamp} envelope around the
+     * value, plus optional metadata and context — and renders it as a JSON Schema document.
+     *
+     * @deprecated composition is no longer this class's concern: it converts between {@link Schema} and JSON
+     *     Schema, and the caller that owns the {@link TagSchemaCreationOutput.DataPointSchema} decides which
+     *     direction to assemble. Retained so adapters built against an earlier SDK keep working. Use
+     *     {@link #toJsonSchemaDocument(Schema)} on a schema you have assembled yourself.
+     */
+    @Deprecated(forRemoval = true)
+    public @NotNull ObjectNode toCompositeSchema(final @NotNull TagSchemaCreationOutput.DataPointSchema dps) {
+        final var builder = new SchemaBuilder().startObject();
+
+        builder.property("tagName").scalar(ScalarType.STRING).readable().writable(false);
+        builder.property("timestamp").scalar(ScalarType.LONG).readable().writable(false);
+        builder.property("value").required().schema(dps.valueSchema()).readable().writable();
+
+        if (dps.metadataSchema() != null) {
+            builder.property("metadata").schema(dps.metadataSchema()).readable().writable(false);
+        }
+        if (dps.context() != null) {
+            builder.property("context").schema(dps.context()).readable().writable(false);
+        }
+
+        return toJsonSchemaDocument(builder.endObject().build());
+    }
+
+    /**
      * Renders a schema as a standalone JSON Schema <em>document</em> — i.e. {@link #toJsonSchema} plus the
      * {@code $schema} declaration that makes the result a self-contained document.
      * <p>

--- a/src/main/java/com/hivemq/adapter/sdk/api/schema/TagSchemaCreationOutput.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/schema/TagSchemaCreationOutput.java
@@ -62,5 +62,35 @@ public interface TagSchemaCreationOutput {
      */
     void tagNotFound(@NotNull String errorMessage);
 
-    record DataPointSchema(@NotNull Schema valueSchema, @Nullable Schema metadataSchema, @Nullable Schema context){};
+    /**
+     * The schema(s) describing a tag's data point.
+     *
+     * @param valueSchema    the readable value shape (northbound / read direction).
+     * @param metadataSchema optional metadata shape; read-only.
+     * @param context        optional context shape; read-only.
+     * @param writeSchema    optional explicit write (southbound) shape. When {@code null}, the write view falls
+     *                       back to {@code valueSchema}. Set this only when the write shape is <em>not</em> a
+     *                       projection of the read shape — e.g. an OPC-UA condition tag whose write target is
+     *                       {@code {eventId, method, comment}}. Note that read-only fields are not pruned from
+     *                       the write view: write-permission cannot be expressed correctly by a static schema
+     *                       (an array of read-only items admits only {@code []}; a required read-only member
+     *                       makes the object unsatisfiable), so it is enforced at validation time, not here.
+     */
+    record DataPointSchema(
+            @NotNull Schema valueSchema,
+            @Nullable Schema metadataSchema,
+            @Nullable Schema context,
+            @Nullable Schema writeSchema) {
+
+        /**
+         * Convenience constructor for the common case: no explicit write schema (the write view is derived
+         * from {@code valueSchema}).
+         */
+        public DataPointSchema(
+                final @NotNull Schema valueSchema,
+                final @Nullable Schema metadataSchema,
+                final @Nullable Schema context) {
+            this(valueSchema, metadataSchema, context, null);
+        }
+    }
 }


### PR DESCRIPTION
**Motivation**

[EDG-845](https://linear.app/hivemq/issue/EDG-845/separate-northbound-read-and-southbound-write-tag-schemas)

An adapter produces one schema per tag. The SDK then wraps it in an envelope (`tagName`, `timestamp`, `metadata`, `context`) that can never be written, and every field carries `readable`/`writable` flags. Consumers use that single schema for both directions, so the southbound mapping editor is handed a schema whose fields are ~80% unwritable and has to neutralise them one by one in the UI.

A tag also needs to be able to describe a write shape that is not a projection of its read shape. An OPC-UA condition tag reads an alarm event but writes `{eventId, method, comment}` — the two share nothing.

**Changes**

- `DataPointSchema` gains a nullable `writeSchema` for tags whose write shape is not a projection of the read shape. A 3-arg convenience constructor keeps every existing call site unchanged, and no adapter needs to set it.
- `SchemaJsonRepresentation` drops `toCompositeSchema`, which assembled the envelope and applied writability semantics — composition concerns in a class whose only job is `Schema` ↔ JSON Schema. It is replaced by `toJsonSchemaDocument`, which renders any `Schema` and adds the `$schema` declaration. The class no longer uses `SchemaBuilder` at all.
- Assembling the per-direction schema now belongs to the caller that owns the `DataPointSchema` (`TagSchemaCreationOutputImpl` in `hivemq-edge`).

Read-only fields are deliberately not pruned from the write view. Write permission cannot be expressed correctly by a static schema — an array of read-only items admits only `[]`, and a required read-only member makes the object unsatisfiable — so it is left to validation time.

Paired with hivemq/hivemq-edge#1705 on the same branch name.