### PR TITLE
EDG-845: Rename the write schema component to southboundSchema

### DIFF
--- a/src/main/java/com/hivemq/adapter/sdk/api/schema/TagSchemaCreationOutput.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/schema/TagSchemaCreationOutput.java
@@ -65,32 +65,64 @@ public interface TagSchemaCreationOutput {
     /**
      * The schema(s) describing a tag's data point.
      *
-     * @param valueSchema    the readable value shape (northbound / read direction).
-     * @param metadataSchema optional metadata shape; read-only.
-     * @param context        optional context shape; read-only.
-     * @param writeSchema    optional explicit write (southbound) shape. When {@code null}, the write view falls
-     *                       back to {@code valueSchema}. Set this only when the write shape is <em>not</em> a
-     *                       projection of the read shape — e.g. an OPC-UA condition tag whose write target is
-     *                       {@code {eventId, method, comment}}. Note that read-only fields are not pruned from
-     *                       the write view: write-permission cannot be expressed correctly by a static schema
-     *                       (an array of read-only items admits only {@code []}; a required read-only member
-     *                       makes the object unsatisfiable), so it is enforced at validation time, not here.
+     * @param valueSchema       the readable value shape (northbound / read direction).
+     * @param metadataSchema    optional metadata shape; read-only.
+     * @param context           optional context shape; read-only.
+     * @param southboundSchema  optional explicit southbound (write) shape. When {@code null}, the southbound view
+     *                          falls back to {@code valueSchema}. Set this only when the southbound shape is
+     *                          <em>not</em> a projection of the read shape — e.g. an OPC-UA condition tag whose
+     *                          write target is {@code {eventId, method, comment}}.
+     *                          <p>
+     *                          <b>Mark it writable.</b> {@link SchemaBuilder} defaults every node to
+     *                          {@code writable = false}, which renders as {@code readOnly: true}. A consumer of
+     *                          the southbound schema — including Edge's own mapping editor — treats a read-only
+     *                          field as a non-destination and does not offer it, so a southbound schema built
+     *                          without {@code .writable()} on its root and on each writable member describes a
+     *                          shape with no write destinations at all. Chain {@code .writable()} explicitly:
+     *                          <pre>{@code
+     * new SchemaBuilder()
+     *         .startObject()
+     *         .property("eventId").required().scalar(ScalarType.STRING).writable()
+     *         .property("method").required().scalar(ScalarType.LONG).writable()
+     *         .property("comment").scalar(ScalarType.STRING).writable()
+     *         .endObject()
+     *         .writable()
+     *         .build()
+     * }</pre>
+     *                          <p>
+     *                          Read-only fields are <em>not</em> pruned from the southbound view: write-permission
+     *                          cannot be expressed correctly by a static schema (an array of read-only items admits
+     *                          only {@code []}; a required read-only member makes the object unsatisfiable). Note
+     *                          that {@code readOnly} is <em>descriptive metadata only</em> — it is a JSON Schema
+     *                          annotation, not an assertion, and no Edge runtime currently rejects a write because
+     *                          it carries a read-only field. Do not rely on it as a safety boundary.
      */
     record DataPointSchema(
             @NotNull Schema valueSchema,
             @Nullable Schema metadataSchema,
             @Nullable Schema context,
-            @Nullable Schema writeSchema) {
+            @Nullable Schema southboundSchema) {
 
         /**
-         * Convenience constructor for the common case: no explicit write schema (the write view is derived
-         * from {@code valueSchema}).
+         * Convenience constructor for the common case: no explicit southbound schema (the southbound view is
+         * derived from {@code valueSchema}).
          */
         public DataPointSchema(
                 final @NotNull Schema valueSchema,
                 final @Nullable Schema metadataSchema,
                 final @Nullable Schema context) {
             this(valueSchema, metadataSchema, context, null);
+        }
+
+        /**
+         * @deprecated "write" is only accurate for a variable-shaped tag. For a condition, method or polled tag
+         *     the southbound shape is a request/command, not a written projection of state — which is precisely
+         *     the case this component exists for. Use {@link #southboundSchema()}, matching the
+         *     {@code NORTHBOUND} / {@code SOUTHBOUND} vocabulary of the public REST API.
+         */
+        @Deprecated(forRemoval = true)
+        public @Nullable Schema writeSchema() {
+            return southboundSchema();
         }
     }
 }

--- a/src/main/java/com/hivemq/adapter/sdk/api/schema/TagSchemaCreationOutput.java
+++ b/src/main/java/com/hivemq/adapter/sdk/api/schema/TagSchemaCreationOutput.java
@@ -113,16 +113,5 @@ public interface TagSchemaCreationOutput {
                 final @Nullable Schema context) {
             this(valueSchema, metadataSchema, context, null);
         }
-
-        /**
-         * @deprecated "write" is only accurate for a variable-shaped tag. For a condition, method or polled tag
-         *     the southbound shape is a request/command, not a written projection of state — which is precisely
-         *     the case this component exists for. Use {@link #southboundSchema()}, matching the
-         *     {@code NORTHBOUND} / {@code SOUTHBOUND} vocabulary of the public REST API.
-         */
-        @Deprecated(forRemoval = true)
-        public @Nullable Schema writeSchema() {
-            return southboundSchema();
-        }
     }
 }


### PR DESCRIPTION
Addresses finding 7 of [Sam's EDG-845 code review](https://linear.app/hivemq/document/sam-code-review-v01-91f16adfceaf).

## Why

`DataPointSchema` gained a fourth component in #132, named `writeSchema`. "Write" is only accurate for a variable-shaped tag. For a condition, method or polled tag the southbound shape is a **request**, not a written projection of state — and that is precisely the case the component exists for. The OPC-UA A&C condition tag, the first consumer, writes `{eventId, method, comment}`, which is a command, not a value.

The public REST API already settled on `NORTHBOUND` / `SOUTHBOUND` (EDG-845). This aligns the SDK with it.

The timing matters more than the change. This is the durable third-party adapter API, and it is the exact place a method/condition author meets the misleading term. Renaming it after adapters adopt the accessor is far more expensive than renaming it now, before the SDK is released.

## What

- Record component `writeSchema` → `southboundSchema`.
- `writeSchema()` retained as a `@Deprecated(forRemoval = true)` delegate, so every existing caller still compiles.
- Javadoc now states the writability contract explicitly, with a worked example.

### The writability contract

`SchemaBuilder` defaults every node to `writable = false`, which renders as `readOnly: true`. Consumers of a southbound schema — including Edge's own mapping editor — treat a read-only field as a non-destination and do not offer it. An adapter that supplies a southbound schema without chaining `.writable()` therefore describes a shape with **no write destinations at all**, and nothing fails loudly; the write form is simply empty.

The Javadoc now says so and shows the correct form. Edge pins both sides of the trap in `TagSchemaCreationOutputImplSchemaBuilderTest`: one test asserts the marked schema carries no `readOnly`, another asserts the unmarked one is entirely `readOnly`.

Also corrected in the Javadoc: `readOnly` was described as "enforced at validation time". It is not. It is a JSON Schema annotation, not an assertion, and no Edge runtime currently rejects a write for carrying a read-only field. It is descriptive metadata and the Javadoc now says that rather than implying a safety boundary.

## Compatibility and sequencing

Source-compatible in both directions:

- The canonical constructor is positional and unchanged — `new DataPointSchema(read, null, null, write)` still compiles. This is what the EDG-835 branch uses.
- `writeSchema()` still resolves, via the delegate.

Edge deliberately keeps calling `writeSchema()` for now. CI resolves the adapter SDK by matching the branch name (`git checkout ${{ github.head_ref }} || true`), so a PR whose branch has no SDK counterpart builds against SDK master. Having Edge switch to `southboundSchema()` before this lands would break every PR stacked on the EDG-845 branch, #1707 included. Edge switches over in a follow-up once this is merged.

## Testing

`./gradlew build` on the SDK; the Edge-side consumers and their tests are green in hivemq/hivemq-edge#1705.
