### PR TITLE
EDG-911: Align jackson with the version Data Hub 3.3.0 requires

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-jackson= "2.22.1"
+jackson= "2.22.2"
 jetbrains-annotations = "24.1.0"
 swagger-annotations = "2.2.52"
 victools="4.38.0"


### PR DESCRIPTION
Part of [EDG-911](https://linear.app/hivemq/issue/EDG-911/data-hub-scripting-engine-pool-exhaustion-persists-on-edge-202612-sup), alongside [hivemq-edge#1722](https://github.com/hivemq/hivemq-edge/pull/1722), [hivemq-data-hub#415](https://github.com/hivemq/hivemq-data-hub/pull/415), [hivemq-edge-commercial-modules#361](https://github.com/hivemq/hivemq-edge-commercial-modules/pull/361), [hivemq-edge-test#439](https://github.com/hivemq/hivemq-edge-test/pull/439) and [hivemq-edge-composite#206](https://github.com/hivemq/hivemq-edge-composite/pull/206).

## Problem

Data Hub 3.3.0 depends on jackson 2.22.2, which moves `hivemq-edge` and `hivemq-edge-test` to 2.22.2 as well. This repo is one of the few that is **not** classloader-isolated in the composite's conflict check, so its 2.22.1 pin then sits on the same main classpath as 2.22.2 and fails the `Check` stage:

```
Found version conflict for module com.fasterxml.jackson.core:jackson-core.
Found version conflict for module com.fasterxml.jackson:jackson-bom.
```

## Solution

`jackson` 2.22.1 to 2.22.2. One line, no source changes.

## Verification

With this branch and the sibling branches checked out, the composite's conflict plugin reports `Build completed.` and exits 0. Without it, the two conflicts above remain after every other repo is aligned.

Note that the branch name matches the other repos deliberately, so the composite job checks them out together.
