### PR TITLE
EDG-924: Exclude the Chakra UI v3 cluster from Renovate updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -12,4 +12,26 @@
     addLabels: [
         'edge-team',
     ],
+    packageRules: [
+        {
+            description: 'Chakra UI v3 is a rewrite with no upgrade path - testing/ui/frontend is on 2.x and the whole theming and component surface it uses was replaced. @chakra-ui/{anatomy,icons,radio,skip-nav,theme-tools,utils} have no v3 release at all. Mirrors the decision taken for the Edge frontend, see EDG-924',
+            matchManagers: [
+                'npm',
+            ],
+            matchPackageNames: [
+                '@chakra-ui/**',
+            ],
+            allowedVersions: '<3',
+        },
+        {
+            description: '@rjsf/chakra-ui v6 peers on @chakra-ui/react >=3.16.1 and chakra-react-select >=6 - blocked by the Chakra UI v3 decision above. The @rjsf packages must move as a set, so the whole scope is held at v5',
+            matchManagers: [
+                'npm',
+            ],
+            matchPackageNames: [
+                '@rjsf/**',
+            ],
+            allowedVersions: '<6',
+        },
+    ],
 }


### PR DESCRIPTION
Mirrors hivemq/hivemq-edge#1725 for this repo, closing the recurring Chakra UI v3 Renovate PRs by encoding the decision in `renovate.json5`.

## Why

`@chakra-ui/react` 3.x is a rewrite with no upgrade path. `testing/ui/frontend` — the only `package.json` in this repo — is on `@chakra-ui/react` 2.10.10 and `@rjsf/*` 5.24.13, and v3 replaced the whole theming and component surface it uses. `@chakra-ui/{anatomy,icons,radio,skip-nav,theme-tools,utils}` have no v3 release at all.

The full analysis behind the decision was done on the Edge frontend and is recorded in EDG-827 / EDG-924. This repo is blocked because it sits on the same Chakra 2 API surface, not on a separately measured error count.

## What changed

Two `packageRules`, each carrying a `description` explaining the block:

| matchPackageNames | allowedVersions | Closes |
| -- | -- | -- |
| `@chakra-ui/**` | `<3` | #118 |
| `@rjsf/**` | `<6` | #127 |

`@rjsf/chakra-ui@6` peers on `@chakra-ui/react >=3.16.1` and `chakra-react-select >=6`, and the `@rjsf/*` packages must move as a set, so the whole scope is held at v5.

The Edge frontend also needs a third rule pinning `chakra-react-select` below 6. That rule is deliberately **not** included here — this frontend has no `chakra-react-select` dependency, so it would be dead config.

`allowedVersions` is used rather than disabling majors, so v2 minor/patch updates keep flowing.

## Verification

`renovate-config-validator` passes.